### PR TITLE
Section about networking and german translations

### DIFF
--- a/docs/configure/networking.de.md
+++ b/docs/configure/networking.de.md
@@ -4,7 +4,7 @@ Viele Geräte, die von KNULLI unterstützt werden, sind in der Lage, sich mit de
 
 ## W-LAN
 
-Wenn dein Gerät einen eingebauten W-LAN-Adapter hat, kannst du ihn direkt via KNULLI konfigurieren. Öffne das Hauptmenü, in dem du den ++"Start"++-Button drückst, gehe zu *Network settings* und konfiguriere dort deine W-LAN-Verbindung. Im unteren Abschnitt *Settings* kannst du W-LAN aktivieren (*Enable WIFI*) und dein W-LAN ahand seiner SSID auswählen. Anschließend kannst du den W-LAN-Schlüssel eingeben, um mit dem W-LAN zu verbinden.
+Wenn dein Gerät einen eingebauten W-LAN-Adapter hat, kannst du ihn direkt via KNULLI konfigurieren. Öffne das Hauptmenü, in dem du den ++"Start"++-Button drückst, gehe zu *Network settings* und konfiguriere dort deine W-LAN-Verbindung. Im unteren Abschnitt *Settings* kannst du W-LAN aktivieren (*Enable WIFI*) und dein W-LAN ahand seiner SSID auswählen. Anschließend kannst du den W-LAN-Schlüssel eingeben und das Menü schließen, um mit dem W-LAN zu verbinden.
 
 Im Abschnitt darüber kannst du sehen, ob du gerade mit einem W-LAN verbunden bist. Außerdem siehst du deine aktuelle IP-Adresse und kannst das Netzwerksymbol ein- oder ausschalten.
 
@@ -12,8 +12,11 @@ Im Abschnitt darüber kannst du sehen, ob du gerade mit einem W-LAN verbunden bi
 
 ### Zusätzliche Sicherheit
 
-Öffne das Hauptmenü, in dem du den ++"Start"++-Button drückst. Dort kannst du *System settings* auswählen und von dort zum Bereich* Security* gelangen. Dort kannst du über den Schalter *Enforce security* erweiterte Sicherheitsmaßnahmen ein- oder ausschalten. Wenn die Sicherheitsmaßnahmen eingeschaltet sind, erscheint unter dem Schalter das *root password*. Dieses Passwort, in Kombination mit dem Benutzernamen `root`, bildet die Zugangsdaten, mit denen auf dein Gerät via Netzwerk zugegriffen werden kann.
+Öffne das Hauptmenü, in dem du den ++"Start"++-Button drückst. Dort kannst du *System settings* auswählen und von dort zum Bereich* Security* gelangen. Dort kannst du über den Schalter *Enforce security* erweiterte Sicherheitsmaßnahmen ein- oder ausschalten. Bitte beachte, dass du das Gerät neustarten musst, um die Änderungen wirksam zu machen.
 
+Wenn du die Sicherheitsmaßnahmen eingeschaltet und das Gerät neu gestartet hast, kannst du in das *Security*-Menü zurückkehren. Unter dem Schalter *Enforce security* erscheint jetzt das aktuelle *root password*. Das Passwort ist zufallsgeneriert und ändert sich manchmal automatisch, wenn Updates installiert werden oder wichtige Einstellungen geändert wurden. Das ist aber kein Grund zur Sorge: Wenn du in dieses Menü zurückkehrst, kannst du jederzeit das aktuelle Root-Passwort einsehen.
+
+Dieses Passwort, in Kombination mit dem Benutzernamen `root`, bildet die Zugangsdaten, mit denen auf dein Gerät via Netzwerk zugegriffen werden kann.
 
 !!! warning "Dir sollte bewusst sein, dass KNULLI für Retro-Gaming und niedrigschwelligen Netzwerkzugang entwickelt wurde. Die erweiterten Sicherheitsmaßnahmen stellen eine zusätzliche Hürde da, um deine Nutzerdaten vor ungewollten Zugriffen zu schützen. Du solltest das Gerät trotzdem nicht mit einem W-LAN verbinden, von dem du nicht sicher bist, dass es sicher ist!"
 

--- a/docs/configure/networking.de.md
+++ b/docs/configure/networking.de.md
@@ -1,0 +1,32 @@
+# Netzwerkverbindungen
+
+Viele Geräte, die von KNULLI unterstützt werden, sind in der Lage, sich mit dem Internet oder anderen lokalen Netzwerken zu verbinden. In den meisten Fällen geschieht dies über den eingebauten W-LAN-Adapter. Allerdings unterstützt KNULLI auch Netzwerkverbindungen über USB-Dongles.
+
+## W-LAN
+
+Wenn dein Gerät einen eingebauten W-LAN-Adapter hat, kannst du ihn direkt via KNULLI konfigurieren. Im Hauptmenü, geh zu *Network settings* und konfiguriere dort deine W-LAN-Verbindung. Im unteren Abschnitt *Settings* kannst du W-LAN aktivieren (*Enable WIFI*) und dein W-LAN ahand seiner SSID auswählen. Anschließend kannst du den W-LAN-Schlüssel eingeben, um mit dem W-LAN zu verbinden.
+
+Im Abschnitt darüber kannst du sehen, ob du gerade mit einem W-LAN verbunden bist. Außerdem siehst du deine aktuelle IP-Adresse und kannst das Netzwerksymbol ein- oder ausschalten.
+
+!!! warning "Standardmäßig ist in KNULLI kein root-Passwort gesetzt. Das bedeutet, dass deine Nutzerdaten-Partition sofort und ohne Passwortschutz zugreifbar ist, sobald du mit einem W-LAN verbindest. In den eigenen vier Wänden mag das ein praktisches Feature sein. Wenn du dein Gerät allerdings mit einem W-LAN verbindest, das nicht unter deiner Kontrolle ist, gehst du damit ein Sicherheitsrisiko ein."
+
+### Zusätzliche Sicherheit
+
+Im Hauptmenü kannst du *System settings* auswählen und von dort zum Bereich* Security* gelangen. Dort kannst du über den Schalter *Enforce security* erweiterte Sicherheitsmaßnahmen ein- oder ausschalten. Wenn die Sicherheitsmaßnahmen eingeschaltet sind, erscheint unter dem Schalter das *root password*. Dieses Passwort, in Kombination mit dem Benutzernamen `root`, bildet die Zugangsdaten, mit denen auf dein Gerät via Netzwerk zugegriffen werden kann.
+
+
+!!! warning "Dir sollte bewusst sein, dass KNULLI für Retro-Gaming und niedrigschwelligen Netzwerkzugang entwickelt wurde. Die erweiterten Sicherheitsmaßnahmen stellen eine zusätzliche Hürde da, um deine Nutzerdaten vor ungewollten Zugriffen zu schützen. Du solltest das Gerät trotzdem nicht mit einem W-LAN verbinden, von dem du nicht sicher bist, dass es sicher ist!"
+
+### Hostname
+
+Der standardmäßige Hostname des Geräts lautet `KNULLI`. Du kannst diesen Namen allerdings ändern, was besonders dann hilfreich sein kann, wenn du mehr als ein KNULLI-betriebenes Gerät in deinem Netzwerk hast. Innerhalb deines Netzwerks sollte der Hostname nach Möglichkeit eindeutig sein.
+
+Windows-User können den Hostnamen nutzen, um das Gerät in ihrem Netzwerk zu finden und darauf zuzugreifen. Wenn das Gerät eingeschaltet und mit deinem Netzwerk verbunden ist, solltest du es im Windows Explorer im Bereich "Netzwerk" finden. Alternativ kannst du darauf zugreifen, in dem du die Adresse in die Adresszeile des Windows Explorers eingibst.
+
+Der Pfad
+```
+\\KNULLI\share
+```
+
+(wobei du`KNULLI` ggf. mit deinem eigenen Hostnamen ersetzen musst) führt direkt zum `/userdata`-Verzeichnis, wo deine ROMs, BIOSe etc. abgelegt sind. Mehr Informationen dazu findest du im Abschnitt [Spiele hinzufügen](../../play/add-games).
+

--- a/docs/configure/networking.de.md
+++ b/docs/configure/networking.de.md
@@ -21,6 +21,8 @@ Im Abschnitt darüber kannst du sehen, ob du gerade mit einem W-LAN verbunden bi
 
 Der standardmäßige Hostname des Geräts lautet `KNULLI`. Du kannst diesen Namen allerdings ändern, was besonders dann hilfreich sein kann, wenn du mehr als ein KNULLI-betriebenes Gerät in deinem Netzwerk hast. Innerhalb deines Netzwerks sollte der Hostname nach Möglichkeit eindeutig sein.
 
+Um den Hostnamen zu ändern, drücke den  ++"Start"++-Button um das Hauptmenü zu öffnen, gehe dann zu *Network settings*, wo du den *Hostname* anpassen kannst.
+
 Windows-User können den Hostnamen nutzen, um das Gerät in ihrem Netzwerk zu finden und darauf zuzugreifen. Wenn das Gerät eingeschaltet und mit deinem Netzwerk verbunden ist, solltest du es im Windows Explorer im Bereich "Netzwerk" finden. Alternativ kannst du darauf zugreifen, in dem du die Adresse in die Adresszeile des Windows Explorers eingibst.
 
 Der Pfad

--- a/docs/configure/networking.de.md
+++ b/docs/configure/networking.de.md
@@ -4,7 +4,7 @@ Viele Geräte, die von KNULLI unterstützt werden, sind in der Lage, sich mit de
 
 ## W-LAN
 
-Wenn dein Gerät einen eingebauten W-LAN-Adapter hat, kannst du ihn direkt via KNULLI konfigurieren. Im Hauptmenü, geh zu *Network settings* und konfiguriere dort deine W-LAN-Verbindung. Im unteren Abschnitt *Settings* kannst du W-LAN aktivieren (*Enable WIFI*) und dein W-LAN ahand seiner SSID auswählen. Anschließend kannst du den W-LAN-Schlüssel eingeben, um mit dem W-LAN zu verbinden.
+Wenn dein Gerät einen eingebauten W-LAN-Adapter hat, kannst du ihn direkt via KNULLI konfigurieren. Öffne das Hauptmenü, in dem du den ++"Start"++-Button drückst, gehe zu *Network settings* und konfiguriere dort deine W-LAN-Verbindung. Im unteren Abschnitt *Settings* kannst du W-LAN aktivieren (*Enable WIFI*) und dein W-LAN ahand seiner SSID auswählen. Anschließend kannst du den W-LAN-Schlüssel eingeben, um mit dem W-LAN zu verbinden.
 
 Im Abschnitt darüber kannst du sehen, ob du gerade mit einem W-LAN verbunden bist. Außerdem siehst du deine aktuelle IP-Adresse und kannst das Netzwerksymbol ein- oder ausschalten.
 
@@ -12,7 +12,7 @@ Im Abschnitt darüber kannst du sehen, ob du gerade mit einem W-LAN verbunden bi
 
 ### Zusätzliche Sicherheit
 
-Im Hauptmenü kannst du *System settings* auswählen und von dort zum Bereich* Security* gelangen. Dort kannst du über den Schalter *Enforce security* erweiterte Sicherheitsmaßnahmen ein- oder ausschalten. Wenn die Sicherheitsmaßnahmen eingeschaltet sind, erscheint unter dem Schalter das *root password*. Dieses Passwort, in Kombination mit dem Benutzernamen `root`, bildet die Zugangsdaten, mit denen auf dein Gerät via Netzwerk zugegriffen werden kann.
+Öffne das Hauptmenü, in dem du den ++"Start"++-Button drückst. Dort kannst du *System settings* auswählen und von dort zum Bereich* Security* gelangen. Dort kannst du über den Schalter *Enforce security* erweiterte Sicherheitsmaßnahmen ein- oder ausschalten. Wenn die Sicherheitsmaßnahmen eingeschaltet sind, erscheint unter dem Schalter das *root password*. Dieses Passwort, in Kombination mit dem Benutzernamen `root`, bildet die Zugangsdaten, mit denen auf dein Gerät via Netzwerk zugegriffen werden kann.
 
 
 !!! warning "Dir sollte bewusst sein, dass KNULLI für Retro-Gaming und niedrigschwelligen Netzwerkzugang entwickelt wurde. Die erweiterten Sicherheitsmaßnahmen stellen eine zusätzliche Hürde da, um deine Nutzerdaten vor ungewollten Zugriffen zu schützen. Du solltest das Gerät trotzdem nicht mit einem W-LAN verbinden, von dem du nicht sicher bist, dass es sicher ist!"

--- a/docs/configure/networking.md
+++ b/docs/configure/networking.md
@@ -4,15 +4,19 @@ Many devices which are supported by KNULLI are capable of connecting to the inte
 
 ## Wi-Fi
 
-If your device has a built-in Wi-Fi adapter, you can set it up directly via KNULLI. Press the ++"Start"++ button to open the main menu, go to *Network settings* where you can configure your Wi-Fi connection. In the lower *Settings* section, enable Wi-Fi, then select your Wi-Fi by its SSID and set the key to connect.
+If your device has a built-in Wi-Fi adapter, you can set it up directly via KNULLI. Press the ++"Start"++ button to open the main menu, go to *Network settings* where you can configure your Wi-Fi connection. In the lower *Settings* section, enable Wi-Fi, then select your Wi-Fi by its SSID, enter your Wi-Fi key, and leave the menu to connect to your Wi-Fi.
 
 In the section above, you can see whether you are currently connected to Wi-Fi, see your current IP address and toggle the network indicator on or off.
 
-!!! warning "By default, your KNULLI device does not have a root password set. Consequently, as soon as you connect to a network, your userdata partition becomes accessible in your local network without any password protection. While this might be convenient within your own home, this might be a security risk when connecting to a network which is not under your control."
+!!! warning "By default, your KNULLI device does not have a root password set. Consequently, as soon as you connect to a network, the data on your device becomes accessible in your local network without any password protection. While this might be convenient within your own home, it might be a severe security risk when connecting to a network which is not under your control."
 
 ### Additional security
 
-Press the ++"Start"++ button to open the main menu, go to *System settings* and find *Security*. There, you can toggle *Enforce security* on or off. If turned on, you will see a *root password* below the toggle. This password and the username `root` must now be used to access the device via network.
+Press the ++"Start"++ button to open the main menu, go to *System settings* and find *Security*. There, you can toggle *Enforce security* on or off. Be aware that you need to restart the device for the change to take effect.
+
+After you enabled additioal security and rebooted your device, return to the *Security* menu. Below the toggle to *Enforce security* you will find the *Root password* now. The root password is generated randomly and sometimes changes automatically when the system receives updates or when major settings have been modified. However, you will always be able to look up your current root password by returning to this menu.
+
+The password and the username `root` must now be used to access the device via network.
 
 !!! warning "Be aware, that KNULLI is built for retro gaming and easy network access. While this setting will make it harder to access your userdata partition, you still should not connect your KNULLI-driven device to any unknown local networks."
 

--- a/docs/configure/networking.md
+++ b/docs/configure/networking.md
@@ -1,0 +1,32 @@
+# Networking
+
+Many devices which are supported by KNULLI are capable of connecting to the internet as well as local networks. In most cases, this is achieved by a built-in Wi-Fi adapter. However, KNULLI also supports network connection via USB dongles.
+
+## Wi-Fi
+
+If your device has a built-in Wi-Fi adapter, you can set it up directly via KNULLI. In the main menu, go to *Network settings* where you can configure your Wi-Fi connection. In the lower *Settings* section, enable Wi-Fi, then select your Wi-Fi by its SSID and set the key to connect.
+
+In the section above, you can see whether you are currently connected to Wi-Fi, see your current IP address and toggle the network indicator on or off.
+
+!!! warning "By default, your KNULLI device does not have a root password set. Consequently, as soon as you connect to a network, your userdata partition becomes accessible in your local network without any password protection. While this might be convenient within your own home, this might be a security risk when connecting to a network which is not under your control."
+
+### Additional security
+
+In the main menu, go to *System settings* and find *Security*. There, you can toggle *Enforce security* on or off. If turned on, you will see a *root password* below the toggle. This password and the username `root` must now be used to access the device via network.
+
+!!! warning "Be aware, that KNULLI is built for retro gaming and easy network access. While this setting will make it harder to access your userdata partition, you still should not connect your KNULLI-driven device to any unknown local networks."
+
+### Hostname
+
+The default hostname of the device will always be `KNULLI`. However, you can pick your own hostname, which might come in handy if you have more that one KNULLI-driven device in your local network. Within your local network, the hostname should be unique, if possible.
+
+Windows users may use the hostname to find the device and access the userdata partition. When the device is turned on and connected to your local network, you will find the device in Windows Explorer at the "Network" section under its hostname. Alternatively, you can access the device directly by typing the path in the address bar of Windows Explorer.
+
+The path
+
+```
+\\KNULLI\share
+```
+
+(replace`KNULLI` with your hostname if you changed it) will lead directly to the `/userdata` folder where you will find your ROMs, BIOSes, etc. See the [Add Games](../../play/add-games) section for more details.
+

--- a/docs/configure/networking.md
+++ b/docs/configure/networking.md
@@ -4,7 +4,7 @@ Many devices which are supported by KNULLI are capable of connecting to the inte
 
 ## Wi-Fi
 
-If your device has a built-in Wi-Fi adapter, you can set it up directly via KNULLI. In the main menu, go to *Network settings* where you can configure your Wi-Fi connection. In the lower *Settings* section, enable Wi-Fi, then select your Wi-Fi by its SSID and set the key to connect.
+If your device has a built-in Wi-Fi adapter, you can set it up directly via KNULLI. Press the ++"Start"++ button to open the main menu, go to *Network settings* where you can configure your Wi-Fi connection. In the lower *Settings* section, enable Wi-Fi, then select your Wi-Fi by its SSID and set the key to connect.
 
 In the section above, you can see whether you are currently connected to Wi-Fi, see your current IP address and toggle the network indicator on or off.
 
@@ -12,13 +12,15 @@ In the section above, you can see whether you are currently connected to Wi-Fi, 
 
 ### Additional security
 
-In the main menu, go to *System settings* and find *Security*. There, you can toggle *Enforce security* on or off. If turned on, you will see a *root password* below the toggle. This password and the username `root` must now be used to access the device via network.
+Press the ++"Start"++ button to open the main menu, go to *System settings* and find *Security*. There, you can toggle *Enforce security* on or off. If turned on, you will see a *root password* below the toggle. This password and the username `root` must now be used to access the device via network.
 
 !!! warning "Be aware, that KNULLI is built for retro gaming and easy network access. While this setting will make it harder to access your userdata partition, you still should not connect your KNULLI-driven device to any unknown local networks."
 
 ### Hostname
 
 The default hostname of the device will always be `KNULLI`. However, you can pick your own hostname, which might come in handy if you have more that one KNULLI-driven device in your local network. Within your local network, the hostname should be unique, if possible.
+
+If you want to change the hostname of your device, press the ++"Start"++ button to open the main menu and go to *Network settings* where you can modify the *Hostname*.
 
 Windows users may use the hostname to find the device and access the userdata partition. When the device is turned on and connected to your local network, you will find the device in Windows Explorer at the "Network" section under its hostname. Alternatively, you can access the device directly by typing the path in the address bar of Windows Explorer.
 

--- a/docs/index.de.md
+++ b/docs/index.de.md
@@ -4,25 +4,25 @@
 
 # Willkommen auf dem KNULLI Wiki :material-gamepad:
 
-KNULLI ist eine benutzerdefinierte Firmware (CFW) für Retro-Gaming-Geräte (Handhelds, Bartops, etc.). Knulli wurde als eine Abspaltung von [Batocera](https://batocera.org) entwickelt und versucht Geräte zu unterstützen, die unter mindestens eine dieser Kategorien fallen:
+KNULLI ist eine unabhängige Custom-Firmware (CFW) für Retro-Gaming-Konsolen (Handhelds, Bartops, etc.). Knulli wird als Fork von [Batocera](https://batocera.org) entwickelt und verfolgt das Ziel, Geräte zu unterstützen, die unter mindestens eine dieser Kategorien fallen:
 
--   Es sind kein quelloffenenr Kernel- und/oder u-boot-Quellcode verfügbar
--   Es gibt Quellcode, aber der Kernel ist entweder nicht Mainline und/oder zu alt (z.B. Geräte mit einem BSP Kernel 3.4 wie der Egret II Mini)
--   Es gibt keine GPU-Unterstützung oder die GPU wird nicht unterstützt, also ist Framebuffer die einzige Option
+-   Es ist kein quelloffener Kernel- und/oder u-boot-Code verfügbar
+-   Es gibt Quellcode, aber der Kernel ist nicht Mainline und/oder zu alt (z.B. Geräte mit einem BSP Kernel 3.4 wie der Egret II Mini)
+-   Es gibt keine GPU-Unterstützung oder die GPU wird nicht unterstützt, d.h. Framebuffer ist die einzige Option
 -   Es ist ein Gerät, das ich besitze und für das ich beschlossen habe eine CFW zu bauen
 
-## Eigenschaften
+## Features
 
-KNULLI unterstützt Geräte mit GPU (GLES-Unterstützung) und nur Framebuffer (Legacy).
+KNULLI unterstützt sowohl Geräte mit GPU (GLES-Unterstützung) als auch Geräte, die nur über Framebuffer verfügen (Legacy).
 
--   Emulation Station Oberfläche für GPU-basierte Geräte
--   Simplemenu/Simplermenu+ für reine Framebuffer-Geräte (auch für GPU-Geräte, falls gewünscht)
+-   Emulation Station als Frontend für GPU-basierte Geräte
+-   Simplemenu/Simplermenu+ als Frontend für reine Framebuffer-Geräte (auch für GPU-Geräte, wenn bevorzugt)
 -   RetroArch inklusive mehrerer libretro-Kerne
--   WLan- und Bluetooth-Unterstützung (einschließlich Audio), sofern vom Gerät unterstützt
--   Unterstützung für externe USB-WLan-Dongles für Geräte ohne interne Wireless-Karte
+-   W-LAN- und Bluetooth-Unterstützung (einschließlich Audio), sofern vom Gerät unterstützt
+-   Unterstützung für externe USB-W-LAN-Dongles für Geräte ohne interne Wireless-Karte
 -   RetroAchievements
 -   Netplay
--   Unterstützung für Cover Art/Thumbnail Scrapper
+-   Unterstützung für Cover-Art/Thumbnail Scraper
 
 ## Community
 
@@ -32,14 +32,14 @@ KNULLI nutzt Discord und [:simple-github: GitHub](https://github.com/knulli-cfw/
 
 KNULLI ist eine Linux-Distribution, die sich aus vielen Open-Source-Komponenten zusammensetzt. Die Komponenten werden unter ihren jeweiligen Lizenzen bereitgestellt. Diese Distribution enthält Komponenten, die nur für den nicht-kommerziellen Gebrauch lizenziert sind.
 
-### Drittanbieter Komponenten
+### Drittanbieter-Komponenten
 
-Alle andere Software wird unter der jeweiligen Lizenz der einzelnen Komponenten bereitgestellt. Diese Lizenzen sind in den Software-Quellen oder im Lizenzordner dieses Projekts zu finden. Änderungen an gebündelter Software und Skripten durch das KNULLI-Team werden unter den Bedingungen der modifizierten Software lizenziert.
+Alle eingebundenen Software-Komponenten werden unter den jeweiligen Lizenzen der einzelnen Komponenten bereitgestellt. Diese Lizenzen sind in den Software-Quellen oder im Lizenzordner dieses Projekts zu finden. Alle Änderungen an den eingebundenen Softwarekomponenten und Skripten durch das KNULLI-Team werden unter den Bedingungen der jeweiligen modifizierten Software lizenziert.
 
 ### Kernel und Bootloader
 
-Die Versionen für einige Geräte enthalten Kernel und/oder Bootloader, für die kein Quellcode verfügbar ist, weil der Hersteller sie nicht veröffentlicht hat. In diesen Fällen enthält die gerätespezifische Seite Anweisungen, um diese aus der Standard-Firmware zu extrahieren.
+Die Versionen für einige Geräte enthalten Kernel und/oder Bootloader, für die kein Quellcode verfügbar ist, weil der Hersteller den Quellcode nicht veröffentlicht hat. In diesen Fällen enthält die gerätespezifische Seite Anweisungen, um diese aus der Standard-Firmware zu extrahieren.
 
 ## Credits
 
-Dieses Projekt ist nicht das Werk einer einzelnen Person, sondern das Werk vieler Personen auf der ganzen Welt, die die Open-Source-Bits entwickelt haben, ohne die dieses Projekt nicht existieren könnte. Besonderer Dank gilt Batocera, muOS, JelOS, CoreELEC, LibreELEC und den Entwicklern und Mitwirkenden der gesamten Open-Source-Gemeinschaft.
+Dieses Projekt ist nicht das Werk einer einzelnen Person, sondern das Werk vieler Personen auf der ganzen Welt, die die Open-Source-Komponenten entwickelt haben, ohne die dieses Projekt nicht existieren könnte. Besonderer Dank gilt Batocera, muOS, JelOS, CoreELEC, LibreELEC und den Entwicklern und Mitwirkenden der gesamten Open-Source-Gemeinschaft.

--- a/docs/index.de.md
+++ b/docs/index.de.md
@@ -2,7 +2,7 @@
   <img class="off-glb" src="/_inc/images/knulli-booting-up.png"/>
 </div>
 
-# Willkommen auf dem KNULLI Wiki :material-gamepad:
+# Willkommen im KNULLI-Wiki :material-gamepad:
 
 KNULLI ist eine unabhängige Custom-Firmware (CFW) für Retro-Gaming-Konsolen (Handhelds, Bartops, etc.). Knulli wird als Fork von [Batocera](https://batocera.org) entwickelt und verfolgt das Ziel, Geräte zu unterstützen, die unter mindestens eine dieser Kategorien fallen:
 

--- a/docs/play/add-games.de.md
+++ b/docs/play/add-games.de.md
@@ -1,0 +1,118 @@
+# :material-layers-plus: Spiele zu KNULLI hinzufügen
+
+Auf dieser Seite findest du alle Möglichkeiten, die KNULLI bereitstellt, um Spiele auf dein Gerät zu laden. Abhängig von dem Gerät, das du benutzt, und den Funktionen, die das Gerät bietet, kannst du unter Umständen aber nicht alle Möglichkeiten nutzen. *(Wenn dein Gerät beispielsweise keine geeignete Hardware hat, um einem Netzwerk beizutreten, kannst du keine Daten via Netzwerk übertragen.)*
+
+Innerhalb von KNULLI wird das Verzeichnis, in dem du deine Nutzerdaten ablegen kannst, als `/userdata` addressiert. Im Ordner `/userdata` befinden sich weitere Unterordner, in denen du Spiele und weitere Dateien ablegen kannst. Die wichtigsten Ordner für dich sind folgende:
+
+* `/userdata`
+    * `/roms` ist der Ordner, in dem du deine Spiele ablegen kannst. Der Ordner enthält bereits diverse Unterordner für verschiedene Systeme. Leg deine Spiele einfach in den Ordner des Systems, für das die Spiele entwickelt wurden.
+    * `/bios` ist der Ordner, in dem du BIOSe ablegen kannst.
+    * `/music` ist der Ordner, in dem du MP3s ablegen kannst, die in EmulationStation als Hintergrundmusik abgespielt werden können.
+    * `/saves` ist der Ordner, in dem deine gespeicherten Spielstände abgelegt werden.
+    * `/screenshots` ist der Ordner, in dem deine gespeicherten Screenshots abgelegt werden.
+    * `/system` ist der Ordner, der deine Einstellungen enthält. Du solltest hier keine Änderungen vornehmen, wenn du nicht weißt, was du tust. Es kann aber nicht schaden, von diesem Ordner regelmäßige Backups anzufertigen.
+
+!!! info "Normalerweise sollte eine frische KNULLI-Installation automatisch ein Verzeichnis für deine Spiele anlegen, das Unterverzeichnisse für alle unterstützten Systeme enthält. Falls das nicht geklappt hat, kannst du im Hauptmenü von EmulationStation unter "System Settings" die Option "CREATE GAME DIRECTORIES" auswählen, um die entsprechenden Unterverzeichnisse anzulegen."
+
+!!! note "Für Details bzgl. der Dateien, die das jeweilige System benötigt, besuche bitte die entsprechenden Seiten im Abschnitt [System](/../system) in diesem Wiki."
+
+## Option 1: Netzwerkübertragung
+
+Netzwerkübertragung kann mit jedem Gerät genutzt werden, das mit dem Internet oder einem lokalen Netzwerk verbunden werden kann. (Das schließt nicht nur Geräte ein, die von sich aus W-LAN- oder kabelnetzwerkefähig sind, sondern auch Geräte, an die man einen externen USB-Dongle anschließen kann.)
+
+Um Netzwerkübertragung zu nutzen, musst du als erstes die Netzwerkverbindungen deines Geräts einrichten. Im Abschnitt [Netzwerkverbindungen](../../configure/networking) findest du Details dazu. Um Daten an dein Gerät via Netzwerk übertragen zu können, benötigst du
+
+* den Hostnamen und/oder die IP-Adresse deines Geräts.
+* das Root-Passwort.
+
+### Windows-Netzwerke (SMB)
+
+KNULLI unterstützt, wie viele andere Betriebssysteme, das Windows-Netzwerkprotokoll SMB. Um Daten via SMB an dein Gerät zu übertragen, hast du verschiedene Möglichkeiten, je nachdem, welche Art von Computer du für die Übertragung nutzt:
+
+- Windows:
+    - Öffne ein Windows-Exploter-Fenster und gib in die Adressleiste entweder `\\[HOSTNAME]` oder `\\[IP-ADRESSE]` ein (ersetze dabei `[HOSTNAME]` mit dem Hostnamen bzw. `[IP-ADRESSE]` mit der IP-Adresse deines Geräts).
+    - Du wirst möglicherweise nach Benutzername und Passwort gefragt, wenn die erweiterten Sicherheitseinstellungen aktiv sind.
+    - Der Benutzername ist `root`, das Passwort wird dir als *Root password* im Bereich *Security* der *System settings* angezeigt.
+- MacOS:
+    - Öffne Finder und wähle *Gehe zu* und dann *Mit Server verbinden* aus dem Hauptmenü.
+    - In der Adressleiste, die jetzt erscheint, musst du `smb://[IP-ADRESSE]` eingeben (ersetze `[IP-ADRESSE]` mit deiner IP-Adresse).
+    - Du wirst möglicherweise nach Benutzername und Passwort gefragt, wenn die erweiterten Sicherheitseinstellungen aktiv sind.
+    - Der Benutzername ist `root`, das Passwort wird dir als *Root password* im Bereich *Security* der *System settings* angezeigt.
+
+Nachdem du dich erfolgreich eingeloggt hast, kannst du den Netzwerkordner `share` sehen, darin ist deine Nutzerdatenpartition (`/userdata`) enthalten. Hier kannst du deine Daten (Spiele etc.) in den dafür vorgesehenen Ordner ablegen.
+
+### FTP
+
+Mit einem FTP-Programm deiner Wahl kannst du eine SFTP-Verbindung zu deinem KNULLI-Gerät aufbauen. Dazu benötigst du den Hostnamen oder die IP-Adresse des Geräts. Stelle sicher, dass als Port `22` eingestellt ist. Der Benutzername lautet `root`, das Passwort wird dir als *Root password* im Bereich *Security* der *System settings* angezeigt.
+
+### HTTP
+
+!!! warning "Dieser Abschnitt ist noch in Bearbeitung. Es tut uns leid, wir arbeiten dran! :smile: Bis es soweit ist kannst du uns via [:simple-discord: Discord](https://discord.gg/HXPS3DAeeB) kontaktieren - vielleicht können wir dir dort helfen!"
+
+### Nach der Übertragung
+
+Wenn du deine Daten vollständig übertragen hast, solltest du auf deinem KNULLI-Gerät im Hauptmenü unter *Game settings* die Option *Update gamelists* wählen. KNULLI wird dann alle ROM-Ordner neu scannen und ggf. hinzugefügte Spiele identifizieren, damit du sie über EmulationStation starten kannst.
+
+## Option 2: SD-Karte
+
+Spiele können via SD-Karte hinzugefügt werden.
+
+### Geräte mit nur einem SD-Karten-Slot
+
+Wenn dein Gerät *keinen* internen Speicher und nur *einen* SD-Karten-Slot hat, musst du KNULLI auf deiner SD-Karte installieren. Auf der SD-Karte wird es dann eine Partition geben, in der deine Nutzerdaten abgelegt werden. Standardmäßig ist diese Partition in ext4 formatiert, einem Dateisystem, das Windows nicht lesen kann. Spiele direkt auf die SD-Karte zu laden ist in diesem Fall leider keine Option. Wenn du unbedingt direkt auf die SD-Karte zugreifen willst, kannst du die Partition allerdings umformatieren, wie im Abschnitt [Einzelnes Speichermedium](#einzelnes-speichermedium) beschrieben.
+
+### Geräte mit zwei SD-Karten-Slots
+
+!!! warning "Dieser Abschnitt ist noch in Bearbeitung. Es tut uns leid, wir arbeiten dran! :smile: Bis es soweit ist kannst du uns via [:simple-discord: Discord](https://discord.gg/HXPS3DAeeB) kontaktieren - vielleicht können wir dir dort helfen!"
+
+### Geräte mit internem Speicher und einem SD-Karten-Slot
+
+!!! warning "Dieser Abschnitt ist noch in Bearbeitung. Es tut uns leid, wir arbeiten dran! :smile: Bis es soweit ist kannst du uns via [:simple-discord: Discord](https://discord.gg/HXPS3DAeeB) kontaktieren - vielleicht können wir dir dort helfen!"
+
+## Option 3: Externe USB-Speicher
+
+!!! warning "Dieser Abschnitt ist noch in Bearbeitung. Es tut uns leid, wir arbeiten dran! :smile: Bis es soweit ist kannst du uns via [:simple-discord: Discord](https://discord.gg/HXPS3DAeeB) kontaktieren - vielleicht können wir dir dort helfen!"
+
+## Option 4: Linux
+
+Wenn du Zugriff auf einen Computer hast, der mit Linux betrieben ist, kannst du deine normale Speicherkarte auch dann lesen und bespielen, wenn sie in ext4 formatiert ist. Steck deine SD-Karte einfach in den Kartenleser deines Linux-Computers um direkten Zugriff auf die Speicherkarte zu erhalten.
+
+## Speichermodi
+
+KNULLI unterstützt sowohl die Benutzung von internem als auch externem Speicher (Micro-SD-Karten) für Spiele. Um Spiele auf das Gerät zu laden und so für KNULLI verfügbar zu machen, haben wir verschiedene Möglichkeiten geschaffen, abhängig davon, welches Dateisystem du benutzt. KNULLI in jedem Speichermodus, den KNULLI unterstützt, stellen wir ein Verzeichnis `roms` bereit, in dem du deine Spiele ablegen kannst. Alle Spiele, die im Ordner `roms` liegen, werden in KNULLI verfügbar sein. An anderen Orten sucht KNULLI *nicht* nach Spielen.
+
+### Einzelnes Speichermedium
+
+Nachdem Knulli auf einer SD-Karte oder einem internen Speicher installiert wurde, stellt es dort eine eigene Partition bereit, in der du deine Benutzerdaten ablegen kannst. Dazu gehören z.B. ROMs, BIOSe, aber auch Themes, Konfigurationsdateien oder Hintergundmusik für EmulationStation. Diese Partition wird standardmäßig mit dem Dateisystem ext4 formatiert, einem Dateisystem, das unter Windows nicht lesbar ist. Linux-Nutzer können die Partition auf der SD-Karte weiterhin lesen und beschreiben, Windows-Nutzer können allerdings auf anderen Wegen auf die Partition zugreifen.
+
+!!! note "Die Partition für Nutzerdaten ist innerhalb von KNULLI als `/userdata` gemountet."
+
+Es ist möglich, die Partition stattdessen mit dem Dateisystem exFAT zu formatieren, um die Partition über ein Kartenlesegerät mit Windows zu lesen und zu beschreiben. exFAT hat allerdings Nachteile bei der Performance und ist limitiert in der zulässigen Dateigröße. Manche Spiele, insbesondere einige Ports, lassen sich nicht ausführen, wenn die Ppartition mit exFAT formatiert ist. Um die Partition trotzdem mit exFAT zu formatieren, währe im KNULLI-Hauptmenü unter *System settings* und *Frontent developer options* die Option *Format a disk*.
+
+### Mehrere Speichermedien
+
+Für Geräte, die mehr als einen Speicher unterstützen (z.B. Geräte mit zwei SD-Karten-Slots oder Geräte mit internem Speicher und SD-Karten-Slot),  stellt KNULLI zwei verschiedene Möglichkeiten bereit.
+
+### Getrennter Speicher (Standard)
+
+Wenn die Option "Zusammengeführter Speicher" deaktiviert ist, oder das zweite/sekundäre Speichermedium in exFAT oder FAT32 formatiert ist, wird Knulli das erste/primäre Speichermedium für das Betriebssystem und alle weiteren Nutzerdaten nutzen und das zweite/sekundäre Speichermedium ausschließlich für Spiele. Wenn das sekundäre Speichermedium über KNULLI formatiert wird, wird automatisch das Verzeichnis `roms` angelegt, in dem die Spiele abgelegt werden können.
+
+Um ein Speichermedium via KNULLI zu formatieren, währe im KNULLI-Hauptmenü unter *System settings* und *Frontent developer options* die Option *Format a disk*.
+
+!!! note "Die Partition des sekundären Speichers wird als `/userdata/games-external` gemountet, der Inhalt des Ordners `roms` (in KNULLI: `/userdata/games-external/roms`) wird dann von KNULLI als `/userdata/roms` verfügbar gemacht."
+
+### Zusammengeführter Speicher
+
+Wenn du ein sekundäres Speichermedium benutzt, das mit dem Linux-Dateisystem ext4 formatiert wurde, kann KNULLI den internen Gerätespeicher und die SD-Karte so zusammenführen, dass beide Speicher genutzt werden können, um Spiele darauf abzulegen. Für diesen Modus gibt es zwei Optionen, mit denen du festlegen kannst, welcher Speicher bevorzugt genutzt werden soll, der interne (Standard) oder der externe.
+
+* Bevorzugt Intern
+  * Dieser Modus wird alles, was in das Verzeichnis `/userdata/roms` geschrieben wird, im internen Speicher ablegen (`/userdata/games-internal/roms`). 
+* Bevorzugt Extern
+  * Dieser Modus wird alles, was in das Verzeichnis `/userdata/roms` geschrieben wird, auf der externen Micro-SD-Karte speichern (`/userdata/games-external/roms`).
+
+!!! note "Zusammengeführter Speicher ist standardmäßig deaktiviert."
+
+### Fehlerbehebung
+
+* Wenn Spiele nicht in der grafischen Oberfläche EmulationStation angezeigt werden, kann die Ursache möglicherweise ein Konflikt im Dateisystem sein. Fehler dieser Art können beseitigt werden, in dem die Funktion `/usr/bin/cleanup_overlay` ausgeführt wird. Um dies zu tun muss allerdings zunächst eine SSH-Verbindung zum Gerät aufgebaut werden. Achtung: Das Gerät wird im Laufe des Clean-Ups neu gestartet!
+* Wenn in `/userdata/roms` keine Unterordner für die verschiedenen Systeme angezeigt werden, kannst du im Hauptmenü von EmulationStation unter "System Settings" die Option "CREATE GAME DIRECTORIES" auswählen, um die entsprechenden Unterverzeichnisse anzulegen. Falls auch danach keine Verzeichnisse enthalten sind, solltest du prüfen, ob auf deinem sekundären Speichermedium ein Ordner `roms` vorliegt (und ihn ggf. selbst anlegen)"

--- a/docs/play/add-games.de.md
+++ b/docs/play/add-games.de.md
@@ -1,20 +1,47 @@
 # :material-layers-plus: Spiele zu KNULLI hinzufügen
 
-Auf dieser Seite findest du alle Möglichkeiten, die KNULLI bereitstellt, um Spiele auf dein Gerät zu laden. Abhängig von dem Gerät, das du benutzt, und den Funktionen, die das Gerät bietet, kannst du unter Umständen aber nicht alle Möglichkeiten nutzen. *(Wenn dein Gerät beispielsweise keine geeignete Hardware hat, um einem Netzwerk beizutreten, kannst du keine Daten via Netzwerk übertragen.)*
+Es gibt verschiedene Möglichkeiten, um Spiele auf dein KNULLI-Gerät zu laden. Welche Möglichkeiten für dich geeignet sind, hängt davon ab, welche Funktionen auf deinem Gerät zur Verfügung stehen. Wenn dein Gerät beispielsweise keine geeignete Hardware hat, um einem Netzwerk beizutreten, kannst du natürlich keine Daten via Netzwerk übertragen. Außerdem spielt es natürlich eine Rolle, welches Gerät dir als Datenquelle zur Verfügung steht.
 
-Innerhalb von KNULLI wird das Verzeichnis, in dem du deine Nutzerdaten ablegen kannst, als `/userdata` addressiert. Im Ordner `/userdata` befinden sich weitere Unterordner, in denen du Spiele und weitere Dateien ablegen kannst. Die wichtigsten Ordner für dich sind folgende:
+## Datenstruktur
+
+Wenn du KNULLI auf einer SD-Karte installierst, werden dabei mehrere Partitionen angelegt, die auf deinem Computer als einzelne Laufwerke angezeigt werden. Die meisten Laufwerke können nur von Linux-Betriebssystemen gelesen werden, unter Windows erscheinen diese Laufwerke unbrauchbar.
+
+!!! danger "Du solltest auf keinen Fall die für Windows unleserlichen KNULLI-Partitionen formatieren, auch wenn Windows es dir vorschlägt."
+
+Nur das Laufwerk *BATOCERA* wird von KNULLI mit FAT32 formatiert, damit du auch von Windows aus darauf zugreifen kannst. Hier liegt allerdings nur das KNULLI-Betriebssystem. Auf der *BATOCERA*-Partition kannst du keine Spiele hinzufügen, du benötigst sie nur, wenn du KNULLI manuell aktualisieren möchtest, wie im Abschnitt [Aktualisieren](../update) beschrieben.
+
+### Die Share-Partition
+
+Die größte Partition auf deiner SD-Karte ist die *SHARE*-Partition. *SHARE* wird von Knulli standardmäßig mit dem Dateisystem ext4 formatiert, daher erscheint das Laufwerk auf Windows-Computern unleserlich. Die *SHARE*-Partition ist das Laufwerk, auf dem KNULLI deine Benutzerdaten ablegt - deine Spiele, Speicherstände, Screenshots, Konfigurationen, usw. Innerhalb von KNULLI wird die *SHARE*-Partition als `/userdata` addressiert.
+
+### Das Nutzerdatenverzeichnis
+
+Im Verzeichnis `/userdata` befinden sich weitere Unterordner, in denen du Spiele und weitere Dateien ablegen kannst. Die wichtigsten Ordner für dich sind folgende:
 
 * `/userdata`
-    * `/roms` ist der Ordner, in dem du deine Spiele ablegen kannst. Der Ordner enthält bereits diverse Unterordner für verschiedene Systeme. Leg deine Spiele einfach in den Ordner des Systems, für das die Spiele entwickelt wurden.
+    * `/roms` ist der Ordner, in dem du deine Spiele ablegen kannst. Der Ordner enthält bereits diverse Unterordner für verschiedene Systeme. Leg deine Spiele einfach in die passenden Ordner für die Systems, für die das jeweilige Spiel entwickelt wurde.
     * `/bios` ist der Ordner, in dem du BIOSe ablegen kannst.
-    * `/music` ist der Ordner, in dem du MP3s ablegen kannst, die in EmulationStation als Hintergrundmusik abgespielt werden können.
+    * `/music` ist der Ordner, in dem du MP3s und OGG-Dateien ablegen kannst, die in EmulationStation als Hintergrundmusik abgespielt werden können. (Die Songs sollten eine Samplerate von 44100Hz haben und eine Bitrate von maximal 256 kb/s.)
     * `/saves` ist der Ordner, in dem deine gespeicherten Spielstände abgelegt werden.
     * `/screenshots` ist der Ordner, in dem deine gespeicherten Screenshots abgelegt werden.
     * `/system` ist der Ordner, der deine Einstellungen enthält. Du solltest hier keine Änderungen vornehmen, wenn du nicht weißt, was du tust. Es kann aber nicht schaden, von diesem Ordner regelmäßige Backups anzufertigen.
 
-!!! info "Normalerweise sollte eine frische KNULLI-Installation automatisch ein Verzeichnis für deine Spiele anlegen, das Unterverzeichnisse für alle unterstützten Systeme enthält. Falls das nicht geklappt hat, kannst du mit dem  ++"Start"++-Button das Hauptmenü von EmulationStation öffnen und unter "System Settings" die Option "CREATE GAME DIRECTORIES" auswählen, um die entsprechenden Unterverzeichnisse anzulegen."
+!!! info "KNULLI sucht ausschließlich im dafür vorgesehenen Ordner `roms` nach Spielen. Spiele, die außerhalb des dafür vorgesehenen Ordners abgelegt werden, werden von KNULLI nicht erkannt."
 
-!!! note "Für Details bzgl. der Dateien, die das jeweilige System benötigt, besuche bitte die entsprechenden Seiten im Abschnitt [System](/../system) in diesem Wiki."
+!!! info "Für Details bzgl. der Dateien, die das jeweilige System benötigt, besuche bitte die entsprechenden Seiten im Abschnitt [Systeme](/../systems) in diesem Wiki."
+
+### Eine zweite SD-Karte verwenden
+
+Wenn du KNULLI auf einem Gerät installierst, das über zwei SD-Karten-Slots verfügt, kannst du den zweiten Slot für eine zweite SD-Karte nutzen, die dann anstelle der *SHARE*-Partition genutzt werden kann:
+
+* Stelle sicher, dass die zweite SD-Karte mit ext4 oder exFAT formatiert ist. (Du musst sie nicht neu formatieren, wenn sie bereits mit ext4 oder exFAT formatiert ist.)
+* Steck die zweite SD-Karte in den dafür vorgesehenen Slot während das Gerät ausgeschaltet ist.
+* Boote KNULLI, öffne das Hauptmenü mit dem  ++"Start"++-Button und gehe  zu *System settings*.
+* Im Abschnitt *Storage* kannst du das *Storage device* auswählen.
+    * Stelle von *Internal* (der "interne" Speicher ist die *SHARE*-Partition deiner KNULLI-SD-Karte) auf den Namen deiner zweiten SD-Karte, z.B. *SHARE - 25.6G*.
+* Reboote KNULLI, um die Änderungen wirksam zu machen, drücke dazu den ++"Start"++-Button und gehe im Hauptmenü zu *Quit* und wähle dort *Restart system*.
+* Beim Neustart wird KNULLI auf deiner zweiten SD-Karte automatisch einen Ordner `/batocera` anlegen und alle Unterordner, die du normalerweise auf der *SHARE*-Partition findest.
+* Wenn die zweite SD-Karte mit exFAT formatiert ist, kannst du die Karte aus dem Slot nehmen, nachdem du das Gerät heruntergefahren hast, und über deinen Computer mit Daten füllen.
 
 ## Option 1: Netzwerkübertragung
 
@@ -23,21 +50,21 @@ Netzwerkübertragung kann mit jedem Gerät genutzt werden, das mit dem Internet 
 Um Netzwerkübertragung zu nutzen, musst du als erstes die Netzwerkverbindungen deines Geräts einrichten. Im Abschnitt [Netzwerkverbindungen](../../configure/networking) findest du Details dazu. Um Daten an dein Gerät via Netzwerk übertragen zu können, benötigst du
 
 * den Hostnamen und/oder die IP-Adresse deines Geräts.
-* das Root-Passwort.
+* das Root-Passwort, wenn erweiterte Sicherheitsmaßnahmen aktiviert sind, wie im Abschnitt [Netzwerkverbindungen](../../configure/networking) beschrieben.
 
-### Windows-Netzwerke (SMB)
+### Windows-Netzwerk (SMB)
 
 KNULLI unterstützt, wie viele andere Betriebssysteme, das Windows-Netzwerkprotokoll SMB. Um Daten via SMB an dein Gerät zu übertragen, hast du verschiedene Möglichkeiten, je nachdem, welche Art von Computer du für die Übertragung nutzt:
 
 - Windows:
     - Öffne ein Windows-Explorer-Fenster und gib in die Adressleiste entweder `\\[HOSTNAME]` oder `\\[IP-ADRESSE]` ein (ersetze dabei `[HOSTNAME]` mit dem Hostnamen bzw. `[IP-ADRESSE]` mit der IP-Adresse deines Geräts).
     - Du wirst möglicherweise nach Benutzername und Passwort gefragt, wenn die erweiterten Sicherheitseinstellungen aktiv sind.
-    - Der Benutzername ist `root`, das Passwort wird dir als *Root password* im Bereich *Security* der *System settings* angezeigt.
+        - Der Benutzername ist `root`, das Passwort wird dir als *Root password* im Bereich *Security* der *System settings* angezeigt.
 - MacOS:
     - Öffne Finder und wähle *Gehe zu* und dann *Mit Server verbinden* aus dem Hauptmenü.
     - In der Adressleiste, die jetzt erscheint, musst du `smb://[IP-ADRESSE]` eingeben (ersetze `[IP-ADRESSE]` mit deiner IP-Adresse).
     - Du wirst möglicherweise nach Benutzername und Passwort gefragt, wenn die erweiterten Sicherheitseinstellungen aktiv sind.
-    - Der Benutzername ist `root`, das Passwort wird dir als *Root password* im Bereich *Security* der *System settings* angezeigt.
+        - Der Benutzername ist `root`, das Passwort wird dir als *Root password* im Bereich *Security* der *System settings* angezeigt.
 
 Nachdem du dich erfolgreich eingeloggt hast, kannst du den Netzwerkordner `share` sehen, darin ist deine Nutzerdatenpartition (`/userdata`) enthalten. Hier kannst du deine Daten (Spiele etc.) in den dafür vorgesehenen Ordner ablegen.
 
@@ -57,62 +84,30 @@ Wenn du deine Daten vollständig übertragen hast, solltest du auf deinem KNULLI
 
 Spiele können via SD-Karte hinzugefügt werden.
 
-### Geräte mit nur einem SD-Karten-Slot
+### Geräte mit nur einer SD-Karte
 
-Wenn dein Gerät *keinen* internen Speicher und nur *einen* SD-Karten-Slot hat, musst du KNULLI auf deiner SD-Karte installieren. Auf der SD-Karte wird es dann eine Partition geben, in der deine Nutzerdaten abgelegt werden. Standardmäßig ist diese Partition in ext4 formatiert, einem Dateisystem, das Windows nicht lesen kann. Spiele direkt auf die SD-Karte zu laden ist in diesem Fall leider keine Option. Wenn du unbedingt direkt auf die SD-Karte zugreifen willst, kannst du die Partition allerdings umformatieren, wie im Abschnitt [Einzelnes Speichermedium](#einzelnes-speichermedium) beschrieben.
+Wie im Abschnitt [Datenstruktur](#datenstruktur) beschrieben, ist die *SHARE*-Partition von KNULLI standardmäßig mit ext4 formatiert und daher unter Windows nicht lesbar. Wenn Netzwerkübertragung nicht möglich ist und du keinen Linux-Computer zur Verfügung hast, gibt es allerdings Lösungen, um doch direkt mit Windows auf die Speicherkarte zuzugreifen.
 
-### Geräte mit zwei SD-Karten-Slots
+#### Die Share-Partition mit exFAT formatieren
 
-!!! warning "Dieser Abschnitt ist noch in Bearbeitung. Es tut uns leid, wir arbeiten dran! :smile: Bis es soweit ist kannst du uns via [:simple-discord: Discord](https://discord.gg/HXPS3DAeeB) kontaktieren - vielleicht können wir dir dort helfen!"
+Es ist möglich, die *SHARE*-Partition mit dem Dateisystem exFAT zu formatieren, um die Partition über ein Kartenlesegerät mit Windows lesen und beschreiben zu können. exFAT hat allerdings Nachteile bei der Performance und ist limitiert in der zulässigen Dateigröße. Manche Spiele, insbesondere einige Ports, lassen sich nicht ausführen, wenn die *SHARE*-Partition mit exFAT formatiert ist.
 
-### Geräte mit internem Speicher und einem SD-Karten-Slot
+Um die Partition trotzdem mit exFAT zu formatieren, öffne das KNULLI-Hauptmenü mit dem  ++"Start"++-Button und wähle unter *System settings* und *Frontent developer options* die Option *Format a disk*. Dort kannst du auswählen, ob du die Partition mit ext4 oder exFAT formatieren möchtest.
 
-!!! warning "Dieser Abschnitt ist noch in Bearbeitung. Es tut uns leid, wir arbeiten dran! :smile: Bis es soweit ist kannst du uns via [:simple-discord: Discord](https://discord.gg/HXPS3DAeeB) kontaktieren - vielleicht können wir dir dort helfen!"
 
-## Option 3: Externe USB-Speicher
+#### Drittanbieter-Software
 
-!!! warning "Dieser Abschnitt ist noch in Bearbeitung. Es tut uns leid, wir arbeiten dran! :smile: Bis es soweit ist kannst du uns via [:simple-discord: Discord](https://discord.gg/HXPS3DAeeB) kontaktieren - vielleicht können wir dir dort helfen!"
+Es gibt Software von Drittanbietern, mit denen man auch unter Windows/MacOS auf Linux-Partitionen zugreifen kann:
 
-## Option 4: Linux
+* Paragon EXTFS für Windows/Mac ist ein kostenpflichtiges Tool, das häufig empfohlen wird und ext2/3/4 unterstützt.
+* DiskGenius für Windows ist ein Tool, von dem eher abgeraten wird, erfahrungsgemäß beschädigt das Tool häufiger Partitionen und ihren Dateninhalt.
+
+!!! danger "Der Einsatz von Drittanbieter-Software wird von uns generell **nicht** empfohlen. Wenn du dich damit auskennst, kannst du versuchen, mit diesem Lösungsansatz zu experimentieren. Du solltest dir aber im Klaren sein, dass du das Risiko eingehst, einen Datenverlust zu erleiden."
+
+### Geräte mit einer zweiten SD-Karte
+
+Wenn dein Gerät über einen Slot für eine zweite SD-Karte verfügt, kannst du einfach eine zweite SD-Karte an deinem Computer mit exFAT formatieren. Anschließend kannst du sie in KNULLI einrichten wie im Abschnitt [Eine zweite SD-Karte verwenden](#eine-zweite-sd-karte-verwenden) beschrieben.
+
+## Option 3: Linux
 
 Wenn du Zugriff auf einen Computer hast, der mit Linux betrieben ist, kannst du deine normale Speicherkarte auch dann lesen und bespielen, wenn sie in ext4 formatiert ist. Steck deine SD-Karte einfach in den Kartenleser deines Linux-Computers um direkten Zugriff auf die Speicherkarte zu erhalten.
-
-## Speichermodi
-
-KNULLI unterstützt sowohl die Benutzung von internem als auch externem Speicher (Micro-SD-Karten) für Spiele. Um Spiele auf das Gerät zu laden und so für KNULLI verfügbar zu machen, haben wir verschiedene Möglichkeiten geschaffen, abhängig davon, welches Dateisystem du benutzt. KNULLI in jedem Speichermodus, den KNULLI unterstützt, stellen wir ein Verzeichnis `roms` bereit, in dem du deine Spiele ablegen kannst. Alle Spiele, die im Ordner `roms` liegen, werden in KNULLI verfügbar sein. An anderen Orten sucht KNULLI *nicht* nach Spielen.
-
-### Einzelnes Speichermedium
-
-Nachdem Knulli auf einer SD-Karte oder einem internen Speicher installiert wurde, stellt es dort eine eigene Partition bereit, in der du deine Benutzerdaten ablegen kannst. Dazu gehören z.B. ROMs, BIOSe, aber auch Themes, Konfigurationsdateien oder Hintergundmusik für EmulationStation. Diese Partition wird standardmäßig mit dem Dateisystem ext4 formatiert, einem Dateisystem, das unter Windows nicht lesbar ist. Linux-Nutzer können die Partition auf der SD-Karte weiterhin lesen und beschreiben, Windows-Nutzer können allerdings auf anderen Wegen auf die Partition zugreifen.
-
-!!! note "Die Partition für Nutzerdaten ist innerhalb von KNULLI als `/userdata` gemountet."
-
-Es ist möglich, die Partition stattdessen mit dem Dateisystem exFAT zu formatieren, um die Partition über ein Kartenlesegerät mit Windows zu lesen und zu beschreiben. exFAT hat allerdings Nachteile bei der Performance und ist limitiert in der zulässigen Dateigröße. Manche Spiele, insbesondere einige Ports, lassen sich nicht ausführen, wenn die Ppartition mit exFAT formatiert ist. Um die Partition trotzdem mit exFAT zu formatieren, öffne das KNULLI-Hauptmenü mit dem  ++"Start"++-Button und wähle unter *System settings* und *Frontent developer options* die Option *Format a disk*.
-
-### Mehrere Speichermedien
-
-Für Geräte, die mehr als einen Speicher unterstützen (z.B. Geräte mit zwei SD-Karten-Slots oder Geräte mit internem Speicher und SD-Karten-Slot),  stellt KNULLI zwei verschiedene Möglichkeiten bereit.
-
-### Getrennter Speicher (Standard)
-
-Wenn die Option "Zusammengeführter Speicher" deaktiviert ist, oder das zweite/sekundäre Speichermedium in exFAT oder FAT32 formatiert ist, wird Knulli das erste/primäre Speichermedium für das Betriebssystem und alle weiteren Nutzerdaten nutzen und das zweite/sekundäre Speichermedium ausschließlich für Spiele. Wenn das sekundäre Speichermedium über KNULLI formatiert wird, wird automatisch das Verzeichnis `roms` angelegt, in dem die Spiele abgelegt werden können.
-
-Um ein Speichermedium via KNULLI zu formatieren, öffne das Hauptmenü, in dem du den ++"Start"++-Button drückst, und wähle im KNULLI-Hauptmenü unter *System settings* und *Frontent developer options* die Option *Format a disk*.
-
-!!! note "Die Partition des sekundären Speichers wird als `/userdata/games-external` gemountet, der Inhalt des Ordners `roms` (in KNULLI: `/userdata/games-external/roms`) wird dann von KNULLI als `/userdata/roms` verfügbar gemacht."
-
-### Zusammengeführter Speicher
-
-Wenn du ein sekundäres Speichermedium benutzt, das mit dem Linux-Dateisystem ext4 formatiert wurde, kann KNULLI den internen Gerätespeicher und die SD-Karte so zusammenführen, dass beide Speicher genutzt werden können, um Spiele darauf abzulegen. Für diesen Modus gibt es zwei Optionen, mit denen du festlegen kannst, welcher Speicher bevorzugt genutzt werden soll, der interne (Standard) oder der externe.
-
-* Bevorzugt Intern
-  * Dieser Modus wird alles, was in das Verzeichnis `/userdata/roms` geschrieben wird, im internen Speicher ablegen (`/userdata/games-internal/roms`). 
-* Bevorzugt Extern
-  * Dieser Modus wird alles, was in das Verzeichnis `/userdata/roms` geschrieben wird, auf der externen Micro-SD-Karte speichern (`/userdata/games-external/roms`).
-
-!!! note "Zusammengeführter Speicher ist standardmäßig deaktiviert."
-
-### Fehlerbehebung
-
-* Wenn Spiele nicht in der grafischen Oberfläche EmulationStation angezeigt werden, kann die Ursache möglicherweise ein Konflikt im Dateisystem sein. Fehler dieser Art können beseitigt werden, in dem die Funktion `/usr/bin/cleanup_overlay` ausgeführt wird. Um dies zu tun muss allerdings zunächst eine SSH-Verbindung zum Gerät aufgebaut werden. Achtung: Das Gerät wird im Laufe des Clean-Ups neu gestartet!
-* Wenn in `/userdata/roms` keine Unterordner für die verschiedenen Systeme angezeigt werden, kannst du mit dem  ++"Start"++-Button das Hauptmenü von EmulationStation öffnen und unter "System Settings" die Option "CREATE GAME DIRECTORIES" auswählen, um die entsprechenden Unterverzeichnisse anzulegen. Falls auch danach keine Verzeichnisse enthalten sind, solltest du prüfen, ob auf deinem sekundären Speichermedium ein Ordner `roms` vorliegt (und ihn ggf. selbst anlegen)"

--- a/docs/play/add-games.de.md
+++ b/docs/play/add-games.de.md
@@ -12,7 +12,7 @@ Innerhalb von KNULLI wird das Verzeichnis, in dem du deine Nutzerdaten ablegen k
     * `/screenshots` ist der Ordner, in dem deine gespeicherten Screenshots abgelegt werden.
     * `/system` ist der Ordner, der deine Einstellungen enthält. Du solltest hier keine Änderungen vornehmen, wenn du nicht weißt, was du tust. Es kann aber nicht schaden, von diesem Ordner regelmäßige Backups anzufertigen.
 
-!!! info "Normalerweise sollte eine frische KNULLI-Installation automatisch ein Verzeichnis für deine Spiele anlegen, das Unterverzeichnisse für alle unterstützten Systeme enthält. Falls das nicht geklappt hat, kannst du im Hauptmenü von EmulationStation unter "System Settings" die Option "CREATE GAME DIRECTORIES" auswählen, um die entsprechenden Unterverzeichnisse anzulegen."
+!!! info "Normalerweise sollte eine frische KNULLI-Installation automatisch ein Verzeichnis für deine Spiele anlegen, das Unterverzeichnisse für alle unterstützten Systeme enthält. Falls das nicht geklappt hat, kannst du mit dem  ++"Start"++-Button das Hauptmenü von EmulationStation öffnen und unter "System Settings" die Option "CREATE GAME DIRECTORIES" auswählen, um die entsprechenden Unterverzeichnisse anzulegen."
 
 !!! note "Für Details bzgl. der Dateien, die das jeweilige System benötigt, besuche bitte die entsprechenden Seiten im Abschnitt [System](/../system) in diesem Wiki."
 
@@ -51,7 +51,7 @@ Mit einem FTP-Programm deiner Wahl kannst du eine SFTP-Verbindung zu deinem KNUL
 
 ### Nach der Übertragung
 
-Wenn du deine Daten vollständig übertragen hast, solltest du auf deinem KNULLI-Gerät im Hauptmenü unter *Game settings* die Option *Update gamelists* wählen. KNULLI wird dann alle ROM-Ordner neu scannen und ggf. hinzugefügte Spiele identifizieren, damit du sie über EmulationStation starten kannst.
+Wenn du deine Daten vollständig übertragen hast, solltest du auf deinem KNULLI-Gerät mit dem  ++"Start"++-Button das Hauptmenü öffnen und unter *Game settings* die Option *Update gamelists* wählen. KNULLI wird dann alle ROM-Ordner neu scannen und ggf. hinzugefügte Spiele identifizieren, damit du sie über EmulationStation starten kannst.
 
 ## Option 2: SD-Karte
 
@@ -87,7 +87,7 @@ Nachdem Knulli auf einer SD-Karte oder einem internen Speicher installiert wurde
 
 !!! note "Die Partition für Nutzerdaten ist innerhalb von KNULLI als `/userdata` gemountet."
 
-Es ist möglich, die Partition stattdessen mit dem Dateisystem exFAT zu formatieren, um die Partition über ein Kartenlesegerät mit Windows zu lesen und zu beschreiben. exFAT hat allerdings Nachteile bei der Performance und ist limitiert in der zulässigen Dateigröße. Manche Spiele, insbesondere einige Ports, lassen sich nicht ausführen, wenn die Ppartition mit exFAT formatiert ist. Um die Partition trotzdem mit exFAT zu formatieren, währe im KNULLI-Hauptmenü unter *System settings* und *Frontent developer options* die Option *Format a disk*.
+Es ist möglich, die Partition stattdessen mit dem Dateisystem exFAT zu formatieren, um die Partition über ein Kartenlesegerät mit Windows zu lesen und zu beschreiben. exFAT hat allerdings Nachteile bei der Performance und ist limitiert in der zulässigen Dateigröße. Manche Spiele, insbesondere einige Ports, lassen sich nicht ausführen, wenn die Ppartition mit exFAT formatiert ist. Um die Partition trotzdem mit exFAT zu formatieren, öffne das KNULLI-Hauptmenü mit dem  ++"Start"++-Button und wähle unter *System settings* und *Frontent developer options* die Option *Format a disk*.
 
 ### Mehrere Speichermedien
 
@@ -97,7 +97,7 @@ Für Geräte, die mehr als einen Speicher unterstützen (z.B. Geräte mit zwei S
 
 Wenn die Option "Zusammengeführter Speicher" deaktiviert ist, oder das zweite/sekundäre Speichermedium in exFAT oder FAT32 formatiert ist, wird Knulli das erste/primäre Speichermedium für das Betriebssystem und alle weiteren Nutzerdaten nutzen und das zweite/sekundäre Speichermedium ausschließlich für Spiele. Wenn das sekundäre Speichermedium über KNULLI formatiert wird, wird automatisch das Verzeichnis `roms` angelegt, in dem die Spiele abgelegt werden können.
 
-Um ein Speichermedium via KNULLI zu formatieren, währe im KNULLI-Hauptmenü unter *System settings* und *Frontent developer options* die Option *Format a disk*.
+Um ein Speichermedium via KNULLI zu formatieren, öffne das Hauptmenü, in dem du den ++"Start"++-Button drückst, und wähle im KNULLI-Hauptmenü unter *System settings* und *Frontent developer options* die Option *Format a disk*.
 
 !!! note "Die Partition des sekundären Speichers wird als `/userdata/games-external` gemountet, der Inhalt des Ordners `roms` (in KNULLI: `/userdata/games-external/roms`) wird dann von KNULLI als `/userdata/roms` verfügbar gemacht."
 
@@ -115,4 +115,4 @@ Wenn du ein sekundäres Speichermedium benutzt, das mit dem Linux-Dateisystem ex
 ### Fehlerbehebung
 
 * Wenn Spiele nicht in der grafischen Oberfläche EmulationStation angezeigt werden, kann die Ursache möglicherweise ein Konflikt im Dateisystem sein. Fehler dieser Art können beseitigt werden, in dem die Funktion `/usr/bin/cleanup_overlay` ausgeführt wird. Um dies zu tun muss allerdings zunächst eine SSH-Verbindung zum Gerät aufgebaut werden. Achtung: Das Gerät wird im Laufe des Clean-Ups neu gestartet!
-* Wenn in `/userdata/roms` keine Unterordner für die verschiedenen Systeme angezeigt werden, kannst du im Hauptmenü von EmulationStation unter "System Settings" die Option "CREATE GAME DIRECTORIES" auswählen, um die entsprechenden Unterverzeichnisse anzulegen. Falls auch danach keine Verzeichnisse enthalten sind, solltest du prüfen, ob auf deinem sekundären Speichermedium ein Ordner `roms` vorliegt (und ihn ggf. selbst anlegen)"
+* Wenn in `/userdata/roms` keine Unterordner für die verschiedenen Systeme angezeigt werden, kannst du mit dem  ++"Start"++-Button das Hauptmenü von EmulationStation öffnen und unter "System Settings" die Option "CREATE GAME DIRECTORIES" auswählen, um die entsprechenden Unterverzeichnisse anzulegen. Falls auch danach keine Verzeichnisse enthalten sind, solltest du prüfen, ob auf deinem sekundären Speichermedium ein Ordner `roms` vorliegt (und ihn ggf. selbst anlegen)"

--- a/docs/play/add-games.de.md
+++ b/docs/play/add-games.de.md
@@ -30,7 +30,7 @@ Um Netzwerkübertragung zu nutzen, musst du als erstes die Netzwerkverbindungen 
 KNULLI unterstützt, wie viele andere Betriebssysteme, das Windows-Netzwerkprotokoll SMB. Um Daten via SMB an dein Gerät zu übertragen, hast du verschiedene Möglichkeiten, je nachdem, welche Art von Computer du für die Übertragung nutzt:
 
 - Windows:
-    - Öffne ein Windows-Exploter-Fenster und gib in die Adressleiste entweder `\\[HOSTNAME]` oder `\\[IP-ADRESSE]` ein (ersetze dabei `[HOSTNAME]` mit dem Hostnamen bzw. `[IP-ADRESSE]` mit der IP-Adresse deines Geräts).
+    - Öffne ein Windows-Explorer-Fenster und gib in die Adressleiste entweder `\\[HOSTNAME]` oder `\\[IP-ADRESSE]` ein (ersetze dabei `[HOSTNAME]` mit dem Hostnamen bzw. `[IP-ADRESSE]` mit der IP-Adresse deines Geräts).
     - Du wirst möglicherweise nach Benutzername und Passwort gefragt, wenn die erweiterten Sicherheitseinstellungen aktiv sind.
     - Der Benutzername ist `root`, das Passwort wird dir als *Root password* im Bereich *Security* der *System settings* angezeigt.
 - MacOS:

--- a/docs/play/add-games.md
+++ b/docs/play/add-games.md
@@ -1,109 +1,112 @@
 # :material-layers-plus: Adding Games to KNULLI
 
-KNULLI has a few options for adding games and the option you choose will depend on the device you have and its available functionality *(For example, some devices do not have networking capabilites so those devices will not be able to use the network transfer option)*.  To create the default set of game directories on your device, choose the 'CREATE GAME DIRECTORIES' option in the System Settings menu.
+KNULLI has a few options for adding games. Depending on the capabilites of your device, you will have to determine which option to choose. For example, some devices do not have networking capabilites, so with those devices you will not be able to use the network transfer options. Additionally, you might have to consider the computer you will use as a data source, since some options are restricted to specific operating systems.
 
-This page will aim to document all possible options and indicate when you might use a given one over another.
+## Data storage structure
 
-!!! note "For details on which specific files each system requires please see the corresponding pages in the systems section of this wiki."
+When you install KNULLI on a SD card, several partitions will be created, which will be shown to you as different drives on your computer. Most of these drives can only be accessed from a Linux operating system. On Windows, they are not accessible.
 
-## Storage Modes
+!!! danger "You should never format the KNULLI partitions which Windows cannot read, no matter how strongly Windows suggests that."
 
-KNULLI has support for using internal and external storage (microsd) for games.  To make games available in the OS we provide different features based on the capability of the filesystem that you are using.  To support our storage modes KNULLI nests games into a directory on your games card called "roms".  All games found in this path will be available in the OS.
+The *BATOCERA* drive will be the only drive which was formatted to FAT32, to make it accessible on Windows. However, this is just the place where the operating system itself is stored, so it is not a place to store your games. You still might need access to the *BATOCERA* partition if you want to update KNULLI manually as described in the [update](../update) section.
 
-### Merged Storage
+### The share partition
 
-When using a microsd that is formatted as Ext4 (Linux), KNULLI will present users with the ability to merge both the internal and external storage together allowing users to use both devices to store games.  This mode has two preferences, external (default), and internal.
+The biggest partition on your SD card is the *SHARE* partition. By default, KNULLI formats the *SHARE* partition to ext4. Therefore, the drive is not accessible on Windows computers. The *SHARE* partition is the drive where your user data is stored - all your games, saved states, screenshots, configurations, etc. Within KNULLI, the *SHARE* partition is mounted as `/userdata`.
 
-* Preference External
-  * This mode will save anything written to `/userdata/roms` to your external microsd (`/userdata/games-external/roms`).
-* Preference Internal
-  * This mode will save anything written to `/userdata/roms` to your internal storage (`/userdata/games-internal/roms`). 
+### The userdata folder
 
-> Note: *Merged Storage is disabled by default.*
+Inside the `/userdata` folder, you will find subfolders, where you can store your games and other files. The most important folders for you to know are the following:
 
-### Simple Storage
+* `/userdata`
+    * `/roms` is the folder, where you can store your games. Inside the folder you will find subfolders for all supported systems. Simply place your game files into the folders of the system the game was made for.
+    * `/bios` is the folder where you can store your BIOSes.
+    * `/music` is the folder where you can store MP3 and OGG files to have them play as background music on EmulationStation. (The songs should have a sample rate of 44100Hz and a bitrate of 256kb/s max.)
+    * `/saves` is the folder where your savegames will be stored.
+    * `/screenshots` is the folder where your screenshots will be stored.
+    * `/system` is the folder where your settings will be stored. You should not change anything in here, unless you are absolutely sure that you know what you are doing. However, it can't hurt to include this folder in your backups.
 
-When Merged Storage is disabled, or when you are using ExFAT or FAT32, KNULLI will mount your external card to `/userdata/games-external` and make the content of `/userdata/games-external/roms` available at /userdata/roms.
+!!! info "KNULLI only scans for games in the `roms` folder. Games which are stored outside of the folder will not be recognized as such."
 
-### Troubleshooting
+!!! info "For details about the files which are required/supported for each system, have a look into the [Systems](/../systems) section of the wiki."
 
-* It is possible to create a conflict which will prevent games from being displayed in EmulationStation.  This can usually be resolved by executing `/usr/bin/cleanup_overlay`.  Note: This will reboot your device.
-* If no game folders appear in /userdata/roms after running `CREATE GAME DIRECTORIES`, make sure you have a `roms` directory on your microsd.
+### Using a second SD card
 
-## Option 1: Network Transfer
+If you use KNULLI on a device which has a second SD card slot, you may use the second slot for a secondary SD card, which can be used instead of the *SHARE* partition:
 
-Network transfer can be used on any device that can connect to the internet (this includes devices with native networking capabilites and ones where networking can be added through an external dongle).
+* Make sure that the second SD card is formatted to ext4 or exFAT. (You don't have to reformat it if it already is formatted to ext4 or exFAT.)
+* Insert the second SD card into the second SD card slot while the device is turned off.
+* Boot KNULLI, open the main menu by pressing the ++"Start"++ button and choose *System settings*.
+* Find the *Storage* section where you can choose your *Storage device*.
+    * Switch fom *Internal* (the "internal" storage is the *SHARE* partition of your KNULLI SD card) to the name of your second SD card, e.g., *SHARE - 25.6G*.
+* Reboot KNULLI to apply the changes by pressing the ++"Start"++ button and choosing *Restart system* in the *Quit* section.
+* During reboot, KNULLI will populate the second SD card with a folder named `/batocera` and all the required subfolders you usually find on the *SHARE* partition.
+* If your second SD card is formatted to exFAT, you can now take the card out of the device when it is shut off. You can put the card in your computer to access it and populate it with your data.
 
-This option first requires you to set up networking on your device.  Please see [Networking](../../configure/networking) for details.  Once you have completed those steps make note of your IP Address in the Network Settings menu.
+## Option 1: Network transfer
 
-In addition to your IP you will also need your root password.  This can be found in the Main Menu by pressing ++"START"++ in EmulationStation and navigating to `System Settings`.  You will see your root password under the `Authentication` header.
+Network transfer can be used on any device which can be connected to the internet or a local network. (This includes devices with native networking capabilites and ones where networking can be added through an external dongle.)
 
-!!! note "By default the root password is set up to rotate to a unique string of characters after every reboot. You can leave it like this and make note of the current password, or you can turn it off and set it to something that will persist."
+This option first requires you to set up networking on your device.  Please see [Networking](../../configure/networking) for details. Once you have completed those steps, you will need
 
-### HTTP
+* the hostname and/or IP address of your device.
+* the root password, if additional security measurements are in place, as explained in the [Networking](../../configure/networking) section.
 
-Enabling Simple HTTP Server in Network settings lets you upload and download files by entering your device's IP address in any browser on the local network (or on VPN IP, see VPN section for details). The username is `root` and the password can be found in `Root Password` in the main menu.
+### Windows networks (SMB)
 
-### SMB
+Like many other operating systems, KNULLI supports SMB, the Windows network protocol. Depending on the type of computer you have, there are different options to transfer your games and other data via SMB:
 
 - Windows:
-    - open a Windows Explorer window, and type in `\\[YOUR IP ADDRESS]`; replace `[YOUR IP ADDRESS]` with the IP Address seen in the Network Settings menu.
-    - You will be prompted for a username and password. 
-    - The username is `root` and your password will be the value from `Root Password` in the System Settings menu.
-- MacOS: 
-    - open Finder and select `Go > Connect to Server` from the top menu.
-    - In the address bar that appears, type `smb://[YOUR IP ADDRESS]`; replace `[YOUR IP ADDRESS]` with the IP Address seen in the Network Settings menu.
-    - You will be prompted for a username and password.
-    - For name enter `root` and your password will be the value from `Root Password` in the System Settings menu.
+    - Open a Windows Explorer window and type either `\\[HOSTNAME]` or `\\[IP-ADDRESS]` into the address bar (replace `[HOSTNAME]` with the hostname or `[IP-ADDRESS]` with the IP address of your device).
+    - If additional security measurements are in place, you will be prompted for your credentials.
+        - The expected username is `root`, the password is the *Root password* shown in the *Security* section of the *System settings*.
+- MacOS:
+    - Open finder, select *Go* and then *Connect to Server* from the top menu.
+    - In the address bar that appears, type either `smb://[HOSTNAME]` or `smb://[IP-ADDRESS]` into the address bar (replace `[HOSTNAME]` with the hostname or `[IP-ADDRESS]` with the IP address of your device).
+    - If additional security measurements are in place, you will be prompted for your credentials.
+        - The expected username is `root`, the password is the *Root password* shown in the *Security* section of the *System settings*.
+
+After you successfully logged in, you will be able to access the `share` partition as a network drive. The network drive corresponds to your `/userdata` folder, so you can put all your data (games, etc.) in the respective folders.
 
 ### FTP
 
-Using your FTP program of choice; set up an SFTP connection to the IP Address seen in the Network Settings menu.  Make sure the Port is set to `22`.  The username is `root` and your password will be the value from `Root Password` in the System Settings menu. 
+Using your FTP program of choice; set up an SFTP connection to the IP address to your KNULLI device. You will need hte hostname or the IP address of the device. Make sure the port is set to `22`. The expected username is `root` and the expected password is the *Root password* you will find in the *Security* section of the *System settings*.
 
-### After connecting
+### HTTP
 
-- You will see a list of folders after you have connected via network.  
-- Open the `roms` folder and you will see a list of folders where games and bios files can be placed. *(Please see the systems section of the wiki for details on where each system's files should be placed)*
-- After you have added your games you can get them to display in EmulationStation by pressing ++"START"++ to open the Main Menu, then open `Game Settings` then select `Update Gamelists` under the Tools header.
+!!! warning "This section is still under construction. Sorry, we're working on it! :smile: Until it's done, you might want to join us on [:simple-discord: Discord](https://discord.gg/HXPS3DAeeB) to get in touch - maybe we can help you there!"
 
-## Option 2: SD Card
+### After transferring your data
 
-Games can also be added via an SD card.  There are 2 primary methods for this depending on your device.
+Once your data is completely transferred, make sure to update your gamelists to make the data available. You can do so by pressing ++"Start"++ to open the main menu, then open *Game settings* and select *Update gamelists*. KNULLI will rescan all game folders and identify all the games you added to make them available in EmulationStation.
 
-### If your device has 2 SD card slots
+## Option 2: SD card
 
-- With your device turned off; insert a FAT32/ExFAT/ext4 formated SD card into slot 2 of your device.
-- Turn your device on.
-- When KNULLI completes its boot process, create your game directories by selecting the `Create Game Directories` option in `System Settings`.
-- Now you can turn off your device, remove your SD card from slot 2 and open it on your PC.
-- You PC will display a list of folders, open the `roms` directory and you will see a list of folders for each system where you can place your games and bios files.
-- Add your games and place your SD card back into slot 2 and boot up KNULLI.
+Under certain circumstances, games can be added directly to your SD card.
 
-If your device does not see your SD card (or write the needed folders to it) please open `System Settings` and make sure `Autodetect Games Card` is turned on (located under the Hardware/Storage header) then reboot your device.
+### Devices with a single SD card
 
-### If your device has 1 SD card slot
+As explained in the [Data storage structure](#data-storage-structure) section, the *SHARE* partition is formatted to ext4 by default. Therefore, it is not accessible on Windows. However, if neither network transfer nor a Linux computer is available to you, there are options to access the SD card from Windows anyway.
 
-!!! warning "This option is only for devices where you have installed KNULLI to the internal drive of the device. In this scenario an SD card can be used directly for storage"
+#### Reformat the share partition to exFAT
 
-- With KNULLI installed to your internal drive press ++"START"++ to open the Main Menu, then open `System Settings` and turn on `Autodetect Games Card` under the Hardware/Storage header.
-- Turn your device off
-- Insert a FAT32/ExFAT/ext4 formated SD card into your device.
-- Turn your device on
-- When KNULLI completes its boot process, create your game directories by selecting the `Create Game Directories` option in `System Settings`.
-- Now you can turn off your device, remove your SD card and open it on your PC.
-- You PC will display a list of folders, open the `roms` directory and you will see a list of folders for each system where you can place your games and bios files.
-- Add your games and place your SD card back into your device and boot up KNULLI.
+It is possible to reformat the *SHARE* partition to exFAT, to make the partition accessible on Windows. Be aware that exFAT has some disadvantages regarding performance and is limited in the max size of its files. Consequently, some games, especially certain ports, will not run on a *SHARE* partition which is formatted to exFAT.
 
-## Option 3: External USB Drive
+To format the partition to exFAT anyway, open the KNULLI main menu by pressing ++"Start"++ and choose *Format a disk* in the *Frontent developer options* section of the *System settings*. You will be able to choose whether you want your partition formatted to ext4 or exFAT.
 
-KNULLI has a built in File Manager and you can use it to access connected USB drives and transfer files. 
+#### Third party software
 
-1. Connect your USB Drive to your device
-2. Open the Tools system and select File Manager
-3. Navigate up to `/` and then select `media` - you should see your drive listed after opening media
-4. Open your drive and you should see its contents
-5. From here you can navigate to the file(s) you would like to copy and then navigate back to the `userdata/roms` directory and paste your copied files in the approrpiate folder.
+Some third-party developers offer software solutions to access Linux file systems from Windows/MacOS:
 
-## Option 4: Linux OS
+* Paragon EXTFS for Windows/Mac is a tool which is not free but it's highly recommended since it allows seamless access to ext2/3/4.
+* DiskGenius on Windows is an tool which we cannot recommend since it performs badly and tends to corrupt the partition and its content.
 
-KNULLI' storage drive is formated as ext4 which can be read natively by linux operating systems.  Plugging in your SD card into an linux OS will enable you to browse the directories and add files directly.
+!!! danger "We generally do **not** recommend using third party software to access Linux file systems. If you know what you are doing, you may try this approach anyway. However, you should be aware that you risk data loss."
+
+### Devices with a second SD card
+
+If you have slot for a second SD card available, you can simply format a second SD card to exFAT on your computer and set it up as explained in the section [Using a second SD card](#using-a-second-sd-card).
+
+## Option 3: Linux
+
+If you have access to a Linux computer, you will be able to access the *SHARE* partition anyway, even if it is formatted to ext4. Simply plug your card into your Linux computer and you will be able to browse the directories and add files directly.

--- a/docs/play/install.de.md
+++ b/docs/play/install.de.md
@@ -1,0 +1,37 @@
+# :material-progress-check: KNULLI installieren
+
+Um KNULLI installieren zu können, musst du als erstes ein passendes Image für dein Gerät herunterladen. Anschließend kannst du das Image auf eine passende SD-Karte (oder den internen Speicher deines Geräts) flashen. Der Installationvorgang beginnt, wenn du dein Gerät zum ersten Mal mit der geflashten SD-Karte (oder dem geflashten internen Speicher) bootest.
+
+## Schritt 1: Image herunterladen [![Latest](https://img.shields.io/github/release/knulli-cfw/distribution.svg?labelColor=111111&color=5998FF&label=Latest&style=flat#only-light)](https://github.com/knulli-cfw/distribution/releases/latest)[![Latest](https://img.shields.io/github/release/knulli-cfw/distribution.svg?labelColor=dddddd&color=5998FF&label=Latest&style=flat#only-dark)](https://github.com/knulli-cfw/distribution/releases/latest)
+
+* Lade die aktuellste Version von KNULLI für dein Gerät von der [Release-Seite](https://github.com/knulli-cfw/distribution/releases/latest) herunter.
+    * Du findest Download-Links für alle Geräte und Plattformen, die von uns unterstützt werden, in der Tabelle "`Installation Package Downloads`".
+    * Stelle sicher, dass du das richtige Image für dein Gerät herunterlädst. Wenn du KNULLI z.B. auf einem [RG35XX](../../devices/anbernic/rg35xx) installieren möchtest, musst du das `rg45xx`-Image herunterladen.
+    * Wenn unklar ist, welches Image für dein Gerät geeignet ist, kannst du im Abschnitt [Unterstützte Geräte](../../devices) überprüfen, welches Image du für dein Gerät herunterladen solltest.
+
+## Schritt 2: Speicher flashen
+
+* Entpacke zunächst das komprimierte Image (z.B. mit [7-Zip](https://7-zip.org/)).
+* Anschließend kannst du das Image mit einem entsprechenden Tool auf deine SD-Karte oder den Gerätespeicher flashen.
+    * Geeignete Software zum Flashen von Images sind u.A. [Rufus](https://rufus.ie/), [Balena](https://balena.io), [Raspberry Pi Imager](https://www.raspberrypi.com/software/) und [Win32 Disk Imager](https://sourceforge.net/projects/win32diskimager/). Falls du die Kommandozeile beherrschst, kannst du auch `dd` verwenden.
+
+## Schritt 3: Boote das Gerät
+
+* (Bei Geräten mit SD-Karte): Steck die SD-Karte in den dafür vorgesehen Slot während das Gerät ausgeschaltet ist und schalte das Gerät danach ein.
+    * Achtung: Bei manchen Geräte muss die Bootreihenfolge so angepasst werden, dass die SD-Karte als erstes angesprochen wird. Überprüfe im Zweifelsfall die Dokumentation für dein Gerät, um zu prüfen, ob es in deinem Fall notwendig ist.
+* Beim ersten Booten läuft KNULLI selbstständig durch den Installationsvorgang und startet das Gerät automatisch neu, sobald die Installation abgeschlossen ist.
+* Am Ende des Reboots wird das Gerät automatisch EmulationStation laden, die grafische Benutzeroberfläche von KNULLI. Die Installation ist jetzt abgeschlossen und du kannst loslegen!
+
+---
+
+## Zusätzliche Hinweise
+
+* Das KNULLI-Betriebssystem ist auf einer ext4-Partition abgelegt, die nur von Linux-Betriebssystemen gelesen werden kann. Windows kann das Dateisystem ext4 nicht ohne zusätzliche Software lesen. Es ist derzeit **nicht** möglich, über Windows direkt auf die primäre KNULLI-Partition zuzugreifen, um Spiele oder andere Nutzerdaten aufzuspielen. Windows-Nutzer können Daten allerdings bequem via W-LAN auf das Gerät spielen, weitere Hinweise dazu findest du im Abschnitt [Spiele hinzufügen](../add-games).
+* Für Geräte, die einen zweiten SD-Karten-Slot haben, kann eine zweite SD-Karte als ext4, FAT32 oder exFAT formatiert werden. (FAT32 und exFAT sind Dateisysteme, die sowohl von Windows als auch von Linux gelesen werden können.) KNULLI wird die zweite SD-Karte automatisch während des Bootvorgangs erkennen und als Speichermedium für Spiele bereitstellen.
+* KNULLI-Images für x86-Geräte enthalten ein Installationsprogramm, das in der grafischen Benutzeroberfläche EmulationStation im Menü "Tools" zu finden ist.
+
+## Nächste Schritte
+
+* [Spiele hinzufügen](/play/add-games)
+* [Netzwerk konfigurieren](/configure/networking)
+* [Themes installieren und konfigurieren](/configure/themes)

--- a/docs/play/update.de.md
+++ b/docs/play/update.de.md
@@ -1,0 +1,26 @@
+#  :material-update: KNULLI aktualisieren
+
+Auf Geräten, die mit dem Internet verbunden werden können, kann KNULLI direkt "Over the Air" (OTA) aktualisiert werden. Alternativ kann die KNULLI-Installation auf deinem Gerät auch aktualisiert werden, in dem du das Update herunterlädst und manuell installierst.
+
+## Option 1: OTA-Updates
+
+Wenn dein Gerät eine aktive Internetverbindung hat, kannst du KNULLI direkt aus EmulationStation heraus aktualisieren:
+
+1. Öffne das Hauptmenü, in dem du den ++"Start"++-Button drückst.
+2. Wähle `Updates & Downloads`.
+3. Gehe zu `Start updates`.
+
+!!! info "Du kannst mit dem Schalter *Check for updates* einstellen, ob du über neue Updates informiert werden möchtest. Unter *Update type* kannst du einstellen, ob du nur "stabile" Releases (*Stable*) oder auch prototypische Vorabversionen (*Butterfy*) installieren möchtest."
+
+## Option 2: Manuelles Update
+
+Wenn dein Gerät keinen Internetzugang hat, oder OTA-Updates aus anderen Gründen nicht möglich sind, kannst du deine KNULLI-Installation auch manuell aktualisieren.
+
+1. Lade das aktuelle Update (`boot.gz`) für dein Gerät von der [Releases-Seite](https://github.com/knulli-cfw/distribution/releases/latest) herunter.
+    * Du findest Download-Links für alle Geräte und Plattformen, die von uns unterstützt werden, in der Tabelle "`Installation Package Downloads`".
+    * Stelle sicher, dass du das richtige Image für dein Gerät herunterlädst. Wenn du KNULLI z.B. auf einem [RG35XX](../../devices/anbernic/rg35xx) installieren möchtest, musst du das `rg45xx`-Image herunterladen.
+    * Wenn unklar ist, welches Image für dein Gerät geeignet ist, kannst du im Abschnitt [Unterstützte Geräte](../../devices) überprüfen, welches Image du für dein Gerät herunterladen solltest.
+2. Entpacke das komprimierte Update  (z.B. mit [7-Zip](https://7-zip.org/)).
+3. Setz deine SD-Karte deiner KNULLI-Installation in deinen Kartenleser am Computer ein.
+4. Ersetze die Datei `boot/knulli` auf der `KNULLI`-Partition deiner SD-Karte durch die Datei `boot/knulli.update` aus dem heruntergeladenen Archiv.
+5. Starte das Gerät erneut, um mit dem Updatevorgang zu beginnen!

--- a/docs/play/update.de.md
+++ b/docs/play/update.de.md
@@ -16,11 +16,11 @@ Wenn dein Gerät eine aktive Internetverbindung hat, kannst du KNULLI direkt aus
 
 Wenn dein Gerät keinen Internetzugang hat, oder OTA-Updates aus anderen Gründen nicht möglich sind, kannst du deine KNULLI-Installation auch manuell aktualisieren.
 
-1. Lade das aktuelle Update (`boot.gz`) für dein Gerät von der [Releases-Seite](https://github.com/knulli-cfw/distribution/releases/latest) herunter.
-    * Du findest Download-Links für alle Geräte und Plattformen, die von uns unterstützt werden, in der Tabelle "`Installation Package Downloads`".
+1. Lade das aktuelle Update (Der Dateiname endet mit `boot.gz` oder `boot.tar.gz`) für dein Gerät von der [Releases-Seite](https://github.com/knulli-cfw/distribution/releases/latest) herunter.
+    * Du findest Download-Links für alle Geräte und Plattformen, die von uns unterstützt werden, in der Tabelle `Installation Package Downloads`.
     * Stelle sicher, dass du das richtige Update für dein Gerät herunterlädst. Wenn du KNULLI z.B. auf einem [RG35XX](../../devices/anbernic/rg35xx) installieren möchtest, musst du das `rg45xx`-Update herunterladen.
     * Wenn unklar ist, welches Image für dein Gerät geeignet ist, kannst du im Abschnitt [Unterstützte Geräte](../../devices) überprüfen, welches Image du für dein Gerät herunterladen solltest.
 2. Entpacke das komprimierte Update  (z.B. mit [7-Zip](https://7-zip.org/)).
 3. Setz deine SD-Karte deiner KNULLI-Installation in deinen Kartenleser am Computer ein.
-4. Ersetze die Datei `boot/knulli` auf der `KNULLI`-Partition deiner SD-Karte durch die Datei `boot/knulli.update` aus dem heruntergeladenen Archiv.
+4. Ersetze die Datei `boot/batocera` auf der *BATOCERA*-Partition deiner SD-Karte durch die Datei `boot/batocera.update` aus dem heruntergeladenen Archiv.
 5. Starte das Gerät erneut, um mit dem Updatevorgang zu beginnen!

--- a/docs/play/update.de.md
+++ b/docs/play/update.de.md
@@ -18,7 +18,7 @@ Wenn dein Gerät keinen Internetzugang hat, oder OTA-Updates aus anderen Gründe
 
 1. Lade das aktuelle Update (`boot.gz`) für dein Gerät von der [Releases-Seite](https://github.com/knulli-cfw/distribution/releases/latest) herunter.
     * Du findest Download-Links für alle Geräte und Plattformen, die von uns unterstützt werden, in der Tabelle "`Installation Package Downloads`".
-    * Stelle sicher, dass du das richtige Image für dein Gerät herunterlädst. Wenn du KNULLI z.B. auf einem [RG35XX](../../devices/anbernic/rg35xx) installieren möchtest, musst du das `rg45xx`-Image herunterladen.
+    * Stelle sicher, dass du das richtige Update für dein Gerät herunterlädst. Wenn du KNULLI z.B. auf einem [RG35XX](../../devices/anbernic/rg35xx) installieren möchtest, musst du das `rg45xx`-Update herunterladen.
     * Wenn unklar ist, welches Image für dein Gerät geeignet ist, kannst du im Abschnitt [Unterstützte Geräte](../../devices) überprüfen, welches Image du für dein Gerät herunterladen solltest.
 2. Entpacke das komprimierte Update  (z.B. mit [7-Zip](https://7-zip.org/)).
 3. Setz deine SD-Karte deiner KNULLI-Installation in deinen Kartenleser am Computer ein.

--- a/docs/play/update.de.md
+++ b/docs/play/update.de.md
@@ -7,8 +7,8 @@ Auf Geräten, die mit dem Internet verbunden werden können, kann KNULLI direkt 
 Wenn dein Gerät eine aktive Internetverbindung hat, kannst du KNULLI direkt aus EmulationStation heraus aktualisieren:
 
 1. Öffne das Hauptmenü, in dem du den ++"Start"++-Button drückst.
-2. Wähle `Updates & Downloads`.
-3. Gehe zu `Start updates`.
+2. Wähle *Updates & downloads*.
+3. Gehe zu *Start updates*.
 
 !!! info "Du kannst mit dem Schalter *Check for updates* einstellen, ob du über neue Updates informiert werden möchtest. Unter *Update type* kannst du einstellen, ob du nur "stabile" Releases (*Stable*) oder auch prototypische Vorabversionen (*Butterfy*) installieren möchtest."
 

--- a/docs/play/update.md
+++ b/docs/play/update.md
@@ -1,24 +1,27 @@
 #  :material-update: Updating KNULLI
 
-KNULLI can be updated "Over the Air" (OTA) for those models with wireless or by manually downloading an update .tar file, adding to your device storage and rebooting.
+On devices, which can be connected to the internet, KNULLI can be updated "over the air" (OTA). Alternatively, KNULLI can also be updated by downloading the respective update file and installing it manually.
 
-## Option 1: OTA Update
+## Option 1: OTA update
 
 If your device has access to the internet you can update KNULLI directly from EmulationStation.
 
 1. In EmulationStation open the main menu by pressing the ++"Start"++ button on your controller.
-2. Select `System Settings`
-3. Scroll to the `System Update` header and select `Start Update`
+2. Select *Updates & downloads*.
+3. Select *Start updates*.
 
-!!! info "You can also view the change log for the latest release by selecting the `Change Log` before you update."
+!!! info "By toggling *Check for updates*, you can decide if you want to be informed about new updates. By selecting an *Update type*, you may choose to only install *Stable* releases or to try out beta versions by selecting (*Butterfy*) installieren möchtest."
 
-## Option 2: Manual Update
+## Option 2: Manual update
 
-If you device does not have access to the internet you can still update manually
+If your device does not have access to the internet or OTA updates are not available for other reasons, you can still update your KNULLI installation manually.
 
-1. Download the latest update (.tar) of KNULLI for your device from the [releases page](https://github.com/knulli-cfw/distribution/releases/latest).
-	* You'll find download links for each device/platform we support under the "`Update Package Downloads`" header.
-    * Make sure to download the correct .tar file for your device. 
-    * If you have any questions you can check the [Device Support](../devices/index.md) section to confirm which .tar you should download for your specific device.
-2. Copy the update to your device's update share.
-3. Reboot the device, and the update will begin automatically.
+
+1. Download the latest update (the file name ends with `boot.gz` or `boot.tar.gz`) for your device from the [Releases page](https://github.com/knulli-cfw/distribution/releases/latest).
+    * You'll find download links for each device/platform we support under the `Update Package Downloads` header.
+    * Make sure to download the correct image for your device.  For example; if you are installing KNULLI on a [RG35XX](../devices/anbernic/rg35xx.md) you would download the `rg35xx` image.
+    * If you have any questions you can check the [Device Support](../devices/index.md) section to confirm which image you should download for your specific device.
+2. Extract the data from the compressed file (e.g. with [7-Zip](https://7-zip.org/)).
+3. Insert your KNULLI SD card into the SD card reader of your computer.
+4. Replace the file `boot/batocera` on the *BATOCERA* partition of your SD card with the file `boot/batocera.update` from the file you downloaded.
+5. Reboot the device, and the update will begin automatically.

--- a/docs/play/update.md
+++ b/docs/play/update.md
@@ -4,13 +4,13 @@ On devices, which can be connected to the internet, KNULLI can be updated "over 
 
 ## Option 1: OTA update
 
-If your device has access to the internet you can update KNULLI directly from EmulationStation.
+If your device has access to the internet, you can update KNULLI directly from EmulationStation.
 
-1. In EmulationStation open the main menu by pressing the ++"Start"++ button on your controller.
+1. In EmulationStation, open the main menu by pressing the ++"Start"++ button on your controller.
 2. Select *Updates & downloads*.
 3. Select *Start updates*.
 
-!!! info "By toggling *Check for updates*, you can decide if you want to be informed about new updates. By selecting an *Update type*, you may choose to only install *Stable* releases or to try out beta versions by selecting (*Butterfy*) installieren möchtest."
+!!! info "By toggling *Check for updates*, you can decide if you want to be informed about new updates. By selecting an *Update type*, you may choose to only install *Stable* releases or to try out beta versions by selecting (*Butterfy*)."
 
 ## Option 2: Manual update
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -121,7 +121,7 @@ plugins:
             Play: Spielen
             Devices: Geräte
             Install: Installation
-            Update: Aktualisierung
+            Update: Aktualisieren
             Add Games: Spiele hinzufügen
             Achievements: Achievements
             Controls: Steuerung

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -123,8 +123,10 @@ plugins:
             Install: Installation
             Update: Aktualisierung
             Add Games: Spiele hinzufügen
-            Achievements: Errungenschaften
+            Achievements: Achievements
             Controls: Steuerung
+            Configure: Konfiguration
+            Networking: Netzwerkverbindungen
             Unbranded: Ohne Marke
         - locale: pl
           name: Polski
@@ -167,6 +169,8 @@ nav:
       - Achievements: play/retro-achievements.md
       - Controls: play/controls.md
       - Netplay: play/netplay.md
+    - Configure:
+      - Networking: configure/networking.md
     - Systems:
       - Engines:
         - Pico-8: systems/pico-8.md


### PR DESCRIPTION
I overhauled the update and add game instructions and I added a section about networking (it was already referred to from the add-games page but it was missing). Additionally, I added some german translations.