### PR TITLE
Fixed a typo in a link

### DIFF
--- a/docs/configure/controls.de.md
+++ b/docs/configure/controls.de.md
@@ -4,7 +4,7 @@
 
 Obwohl KNULLI eigentlich für Handheld-Geräte entwickelt wurde, unterstützt es zusätzlich viele verschiedene Arten von USB- und Bluetooth-Controllern. Bevor du einen Controller an deinem KNULLI-Gerät verwenden kannst, kann es allerdings nötig sein, die Tasten des Controllers ihren jeweiligen Funktionen zuzuordnen.
 
-!!! danger "Verwechsel die Einrichtung des Controllers nicht mit der Anpassung der Tastenbelegung für einzelne *Spiele* oder *Emulation-Cores*! In diesem Abschnitt geht es um die *generelle* Einrichtung der *Hardware*. Wenn du die Tastenbelegung für einzelne *Spiele*, emulierte Konsolen oder die dafür eingesetzten *Emulation-Cores* anpassen möchtest, schau bitte in die Anleitung für den jeweiligen *Core* (z.B. [Retroarch](./retroarch/controls))."
+!!! danger "Verwechsel die Einrichtung des Controllers nicht mit der Anpassung der Tastenbelegung für einzelne *Spiele* oder *Emulation-Cores*! In diesem Abschnitt geht es um die *generelle* Einrichtung der *Hardware*. Wenn du die Tastenbelegung für einzelne *Spiele*, emulierte Konsolen oder die dafür eingesetzten *Emulation-Cores* anpassen möchtest, schau bitte in die Anleitung für den jeweiligen *Core* (z.B. [Retroarch](../retroarch/controls))."
 
 ## Controller einrichten
 

--- a/docs/configure/controls.md
+++ b/docs/configure/controls.md
@@ -4,7 +4,7 @@
 
 Even though it was designed for handheld devices, KNULLI still supports various types of USB and Bluetooth controllers. However, before a controller can be used with your KNULLI device, it might be necessary to map its buttons and directional controls to the corresponding game inputs.
 
-!!! danger "Do not confuse controller setup with* game-* or *core-specific* button remapping! This section is about the *global* controller setup to make the *hardware* work. If you want to remap the controls for a specific *game* or *emulation core*, follow the guide for the respective core (e.g. [Retroarch](./retroarch/controls))."
+!!! danger "Do not confuse controller setup with* game-* or *core-specific* button remapping! This section is about the *global* controller setup to make the *hardware* work. If you want to remap the controls for a specific *game* or *emulation core*, follow the guide for the respective core (e.g. [Retroarch](../retroarch/controls))."
 
 ## Controller mapping
 


### PR DESCRIPTION
Fixed a typo which broke links from contols page to retroarch controls page. (Sorry.)