### PR TITLE
fix typo and minors in German install docs

### DIFF
--- a/docs/play/install.de.md
+++ b/docs/play/install.de.md
@@ -6,16 +6,16 @@ Um KNULLI installieren zu können, musst du als erstes ein passendes Image für 
 
 * Lade die aktuellste Version von KNULLI für dein Gerät von der [Release-Seite](https://github.com/knulli-cfw/distribution/releases/latest) herunter.
     * Du findest Download-Links für alle Geräte und Plattformen, die von uns unterstützt werden, in der Tabelle "`Installation Package Downloads`".
-    * Stelle sicher, dass du das richtige Image für dein Gerät herunterlädst. Wenn du KNULLI z.B. auf einem [RG35XX](../../devices/anbernic/rg35xx) installieren möchtest, musst du das `rg45xx`-Image herunterladen.
+    * Stelle sicher, dass du das richtige Image für dein Gerät herunterlädst. Wenn du KNULLI z.B. auf einem [RG35XX](../../devices/anbernic/rg35xx) installieren möchtest, musst du das `rg35xx`-Image herunterladen.
     * Wenn unklar ist, welches Image für dein Gerät geeignet ist, kannst du im Abschnitt [Unterstützte Geräte](../../devices) überprüfen, welches Image du für dein Gerät herunterladen solltest.
 
-!!! warning "Falls dein Gerät *nicht* ist der Liste der `Installation Package Downloads` enthalten ist, gibt es noch keine öffentlich zugängliche Releaseversion von Knulli für dein Gerät. Du solltest *nicht* versuchen, ein Installationspaket für ein anderes Gerät zu installieren."
+!!! warning "Falls dein Gerät *nicht* ist der Liste der `Installation Package Downloads` enthalten ist, gibt es noch keine öffentlich zugängliche Release-Version von Knulli für dein Gerät. Du solltest *nicht* versuchen, ein Installationspaket für ein anderes Gerät zu installieren."
 
 ## Schritt 2: Speicher flashen
 
 * Entpacke zunächst das komprimierte Image (z.B. mit [7-Zip](https://7-zip.org/)).
 * Anschließend kannst du das Image mit einem entsprechenden Tool auf deine SD-Karte oder den Gerätespeicher flashen.
-    * Geeignete Software zum Flashen von Images sind u.A. [Rufus](https://rufus.ie/), [Balena](https://balena.io), [Raspberry Pi Imager](https://www.raspberrypi.com/software/) und [Win32 Disk Imager](https://sourceforge.net/projects/win32diskimager/). Falls du die Kommandozeile beherrschst, kannst du auch `dd` verwenden.
+    * Geeignete Software zum Flashen von Images sind u.a. [Rufus](https://rufus.ie/), [Balena](https://balena.io), [Raspberry Pi Imager](https://www.raspberrypi.com/software/) und [Win32 Disk Imager](https://sourceforge.net/projects/win32diskimager/). Falls du die Kommandozeile beherrschst, kannst du auch `dd` verwenden.
 
 Während des Flashens werden mehrere Partitionen angelegt, die auf deinem Computer als einzelne Laufwerke angezeigt werden. Die meisten Laufwerke können nur von Linux-Betriebssystemen gelesen werden, unter Windows erscheinen diese Laufwerke unbrauchbar.
 
@@ -29,7 +29,7 @@ Nur das Laufwerk *BATOCERA* wird von KNULLI mit FAT32 formatiert, damit du auch 
 
 ## Schritt 3: Boote das Gerät
 
-* Steck die SD-Karte in den dafür vorgesehen Slot während das Gerät ausgeschaltet ist.
+* Stecke die SD-Karte in den dafür vorgesehen Slot während das Gerät ausgeschaltet ist.
     * Falls das Gerät einen zweiten SD-Karten-Slot hat, solltest du vor dem ersten Hochfahren sicherstellen, dass der zweite Slot leer ist.
 * Schalte das Gerät ein.
     * Achtung: Bei manchen Geräte muss die Bootreihenfolge so angepasst werden, dass die SD-Karte als erstes angesprochen wird. Überprüfe im Zweifelsfall die Dokumentation für dein Gerät, um zu prüfen, ob es in deinem Fall notwendig ist.


### PR DESCRIPTION
This fixes a typos and a few minor spelling issues in the German install doc