### PR TITLE
Fix typo in shaders.md from 'config/' to 'configs/'

### DIFF
--- a/docs/configure/customization/shaders.md
+++ b/docs/configure/customization/shaders.md
@@ -64,7 +64,7 @@ Gain access to your device, either by direct access to the SD card or via [netwo
 Inside the new `shaders` folder, you will need at least two sub-folders for specific files:
 
 * `shaders/`
-    * `config/` will hold a **sub-folder** for every shader configuration you want to add to Emulation Station which will be populated with a simple text file called `rendering-defaults.yml` as explained below
+    * `configs/` will hold a **sub-folder** for every shader configuration you want to add to Emulation Station which will be populated with a simple text file called `rendering-defaults.yml` as explained below
     * `presets/` will hold your presets, usually `.glslp` files
     * `shaders/` will hold the actual shaders, usually in a **sub-folder** for every shader or shader set, usually `.glsl` files
 


### PR DESCRIPTION
Identified by l0ader in discord
https://discord.com/channels/1173228527605272666/1227424871449890927/1415257742746193930

Confirmed path against [batocera docs](https://wiki.batocera.org/emulationstation:shaders_set#what_if_i_want_to_create_my_own_shader_set)